### PR TITLE
feat: numbered select for all interactive prompts

### DIFF
--- a/checkpoint/checkpoint.ts
+++ b/checkpoint/checkpoint.ts
@@ -16,6 +16,7 @@
  */
 
 import { spawn } from "child_process";
+import { numberedSelect } from "../ui.js";
 import {
   isGitRepo,
   getRepoRoot,
@@ -388,7 +389,7 @@ async function handleRestorePrompt(
     ? new Date(targetEntry.timestamp).getTime()
     : Date.now();
 
-  const choice = await ctx.ui.select(
+  const choice = await numberedSelect(ctx,
     "Restore code state?",
     restoreOptions.map((o) => o.label)
   );

--- a/lsp/lsp.ts
+++ b/lsp/lsp.ts
@@ -16,6 +16,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import { type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
+import { numberedSelect } from "../ui.js";
 import { type Diagnostic } from "vscode-languageserver-protocol";
 import { LSP_SERVERS, formatDiagnostic, getOrCreateManager, shutdownManager } from "./lsp-core.js";
 
@@ -370,7 +371,7 @@ export default function (pi: ExtensionAPI) {
         label: mode === hookMode ? `${labelForMode(mode)}${currentMark}` : labelForMode(mode),
       }));
 
-      const modeChoice = await ctx.ui.select(
+      const modeChoice = await numberedSelect(ctx,
         "LSP auto diagnostics hook mode:",
         modeOptions.map((option) => option.label),
       );
@@ -390,7 +391,7 @@ export default function (pi: ExtensionAPI) {
         },
       ];
 
-      const scopeChoice = await ctx.ui.select(
+      const scopeChoice = await numberedSelect(ctx,
         "Apply LSP auto diagnostics hook setting to:",
         scopeOptions.map((option) => option.label),
       );

--- a/permission/permission.ts
+++ b/permission/permission.ts
@@ -41,6 +41,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { numberedSelect } from "../ui.js";
 import {
   type PermissionLevel,
   type PermissionMode,
@@ -286,7 +287,7 @@ export async function handlePermissionCommand(
     const newLevel = arg as PermissionLevel;
 
     if (hasInteractiveUI(ctx)) {
-      const scope = await ctx.ui.select("Save permission level to:", [
+      const scope = await numberedSelect(ctx, "Save permission level to:", [
         "Session only",
         "Global (persists)",
       ]);
@@ -318,14 +319,14 @@ export async function handlePermissionCommand(
     return `${info.label}: ${info.desc}${marker}`;
   });
 
-  const choice = await ctx.ui.select("Select permission level", options);
+  const choice = await numberedSelect(ctx, "Select permission level", options);
   if (!choice) return;
 
   const selectedLabel = choice.split(":")[0].trim();
   const newLevel = LEVELS.find((l) => LEVEL_INFO[l].label === selectedLabel);
   if (!newLevel || newLevel === state.currentLevel) return;
 
-  const scope = await ctx.ui.select("Save to:", ["Session only", "Global (persists)"]);
+  const scope = await numberedSelect(ctx, "Save to:", ["Session only", "Global (persists)"]);
   if (!scope) return;
 
   setLevel(state, newLevel, scope === "Global (persists)", ctx);
@@ -345,7 +346,7 @@ export async function handlePermissionModeCommand(
     const newMode = arg as PermissionMode;
 
     if (hasInteractiveUI(ctx)) {
-      const scope = await ctx.ui.select("Save permission mode to:", [
+      const scope = await numberedSelect(ctx, "Save permission mode to:", [
         "Session only",
         "Global (persists)",
       ]);
@@ -375,14 +376,14 @@ export async function handlePermissionModeCommand(
     return `${info.label}: ${info.desc}${marker}`;
   });
 
-  const choice = await ctx.ui.select("Select permission mode", options);
+  const choice = await numberedSelect(ctx, "Select permission mode", options);
   if (!choice) return;
 
   const selectedLabel = choice.split(":")[0].trim();
   const newMode = PERMISSION_MODES.find((m) => PERMISSION_MODE_INFO[m].label === selectedLabel);
   if (!newMode || newMode === state.permissionMode) return;
 
-  const scope = await ctx.ui.select("Save to:", ["Session only", "Global (persists)"]);
+  const scope = await numberedSelect(ctx, "Save to:", ["Session only", "Global (persists)"]);
   if (!scope) return;
 
   setMode(state, newMode, scope === "Global (persists)", ctx);
@@ -454,7 +455,7 @@ Use /permission-mode ask to enable confirmations.`
     }
 
     playPermissionSound();
-    const choice = await ctx.ui.select(
+    const choice = await numberedSelect(ctx,
       `⚠️ Dangerous command`,
       ["Allow once", "Cancel"]
     );
@@ -495,7 +496,7 @@ Use /permission ${requiredLevel} or /permission-mode ask to enable prompts.`
 
   // Interactive mode: prompt
   playPermissionSound();
-  const choice = await ctx.ui.select(
+  const choice = await numberedSelect(ctx,
     `Requires ${requiredInfo.label}`,
     ["Allow once", `Allow all (${requiredInfo.label})`, "Cancel"]
   );
@@ -553,7 +554,7 @@ Use /permission low or /permission-mode ask to enable prompts.`
 
   // Interactive mode: prompt
   playPermissionSound();
-  const choice = await ctx.ui.select(
+  const choice = await numberedSelect(ctx,
     message,
     ["Allow once", "Allow all (Low)", "Cancel"]
   );

--- a/repeat/repeat.ts
+++ b/repeat/repeat.ts
@@ -1,6 +1,7 @@
 /// <reference path="./types.d.ts" />
 
 import { spawnSync } from "node:child_process";
+import { numberedSelect } from "../ui.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -410,7 +411,7 @@ export default function (pi: ExtensionAPI) {
 
 				let mode: "repeat" | "edit" = "repeat";
 				if (externalEditor) {
-					const choice = await ctx.ui.select("Repeat write:", [
+					const choice = await numberedSelect(ctx, "Repeat write:", [
 						"Re-write same content",
 						"Open in $EDITOR",
 					]);
@@ -475,7 +476,7 @@ export default function (pi: ExtensionAPI) {
 
 				let mode: "repeat" | "open" = "repeat";
 				if (externalEditor) {
-					const choice = await ctx.ui.select("Repeat edit:", [
+					const choice = await numberedSelect(ctx, "Repeat edit:", [
 						"Repeat the Edit",
 						"Open file at changed line",
 					]);

--- a/ui.ts
+++ b/ui.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared UI utilities for pi-hooks extensions.
+ */
+import { Text, matchesKey } from "@mariozechner/pi-tui";
+
+/**
+ * Like ctx.ui.select() but options are numbered and pressing a digit key
+ * instantly selects the corresponding item. Also supports arrow keys + enter.
+ * Escape cancels (returns null).
+ */
+export async function numberedSelect(
+  ctx: any,
+  title: string,
+  options: string[],
+): Promise<string | null> {
+  return ctx.ui.custom<string | null>((tui: any, theme: any, _kb: any, done: (v: string | null) => void) => {
+    let selected = 0;
+
+    function buildText() {
+      const lines: string[] = [];
+      lines.push(theme.bold(theme.fg("warning", title)));
+      lines.push("");
+      for (let i = 0; i < options.length; i++) {
+        const marker = i === selected ? theme.fg("accent", "▸") : " ";
+        const label = i === selected ? theme.fg("accent", options[i]) : options[i];
+        lines.push(`  ${marker} ${theme.bold(String(i + 1))}  ${label}`);
+      }
+      return lines.join("\n");
+    }
+
+    const text = new Text(buildText(), 0, 0);
+
+    return {
+      render: (w: number) => text.render(w),
+      invalidate: () => text.invalidate(),
+      handleInput: (data: string) => {
+        // Number keys 1-9
+        const num = parseInt(data, 10);
+        if (num >= 1 && num <= options.length) {
+          done(options[num - 1]);
+          return;
+        }
+        // Arrow down / j
+        if (matchesKey(data, "down") || data === "j") {
+          selected = (selected + 1) % options.length;
+          text.setText(buildText());
+          tui.requestRender();
+          return;
+        }
+        // Arrow up / k
+        if (matchesKey(data, "up") || data === "k") {
+          selected = (selected - 1 + options.length) % options.length;
+          text.setText(buildText());
+          tui.requestRender();
+          return;
+        }
+        // Enter
+        if (matchesKey(data, "return")) {
+          done(options[selected]);
+          return;
+        }
+        // Escape
+        if (matchesKey(data, "escape")) {
+          done(null);
+          return;
+        }
+      },
+    };
+  });
+}


### PR DESCRIPTION
## What

Adds a shared `numberedSelect()` component (`ui.ts`) that replaces all `ctx.ui.select()` calls across every extension. Users can now:

- **Press 1-9** to instantly pick an option
- **Arrow keys / j/k + Enter** to navigate and confirm
- **Escape** to cancel

## Where

Applied to all interactive prompts in:
- **permission** — tool call gates, `/permission`, `/permission-mode`
- **checkpoint** — restore prompt
- **repeat** — write/edit prompts
- **lsp** — mode and scope selection

## How

New `ui.ts` at the package root exports `numberedSelect(ctx, title, options)`. It uses `ctx.ui.custom()` with a proper TUI component (`render`, `invalidate`, `handleInput`). Styling uses `theme.bold()` / `theme.fg()` to respect the active theme. The currently highlighted option shows a ▸ marker.