### PR TITLE
feat(lsp): add Ruby language server support

### DIFF
--- a/lsp/README.md
+++ b/lsp/README.md
@@ -8,7 +8,7 @@ Language Server Protocol integration for pi-coding-agent.
 - **Tool** (`lsp-tool.ts`): On-demand LSP queries (definitions, references, hover, symbols, diagnostics, signatures)
 - Manages one LSP server per project root and reuses them across turns
 - **Efficient**: Bounded memory usage via LRU cache and idle file cleanup
-- Supports TypeScript/JavaScript, Vue, Svelte, Dart/Flutter, Python, Go, Kotlin, Swift, and Rust
+- Supports TypeScript/JavaScript, Vue, Svelte, Dart/Flutter, Python, Go, Kotlin, Swift, Rust, and Ruby
 
 ## Supported Languages
 
@@ -23,6 +23,7 @@ Language Server Protocol integration for pi-coding-agent.
 | Kotlin | `kotlin-ls` | `settings.gradle(.kts)`, `build.gradle(.kts)`, `pom.xml` |
 | Swift | `sourcekit-lsp` | `Package.swift`, Xcode (`*.xcodeproj` / `*.xcworkspace`) |
 | Rust | `rust-analyzer` | `Cargo.toml` |
+| Ruby | `ruby-lsp` ([configurable](#ruby-server)) | `Gemfile`, `.ruby-version` |
 
 ### Known Limitations
 
@@ -69,6 +70,10 @@ xcrun sourcekit-lsp --help
 
 # Rust (install via rustup)
 rustup component add rust-analyzer
+
+# Ruby
+gem install ruby-lsp  # optional if using rubocop only, see Ruby Server Selection
+gem install rubocop
 ```
 
 The extension spawns binaries from your PATH.
@@ -147,6 +152,12 @@ To disable auto diagnostics, choose "Disabled" in `/lsp` or set in `~/.pi/agent/
 Other values: `"agent_end"` (default) and `"edit_write"`.
 
 Agent-end mode analyzes files touched during the full agent response (after all tool calls complete) and posts a diagnostics message only once. Disabling the hook does not disable the `/lsp` tool.
+
+### Ruby Server
+
+Optionally set `lsp.rubyServer` in `~/.pi/agent/settings.json`:
+- `"ruby-lsp"` (default) — full IDE features, integrates RuboCop when installed
+- `"rubocop"` — diagnostics and formatting only, [faster startup](https://github.com/sst/opencode/releases/tag/v1.0.81)
 
 ## File Structure
 

--- a/lsp/lsp-core.ts
+++ b/lsp/lsp-core.ts
@@ -58,6 +58,7 @@ export const LANGUAGE_IDS: Record<string, string> = {
   ".py": "python", ".pyi": "python", ".go": "go", ".rs": "rust",
   ".kt": "kotlin", ".kts": "kotlin",
   ".swift": "swift",
+  ".rb": "ruby", ".rake": "ruby", ".gemspec": "ruby", ".ru": "ruby",
 };
 
 // Types
@@ -351,6 +352,22 @@ async function spawnSourcekitLsp(root: string): Promise<ChildProcessWithoutNullS
   return spawnWithFallback(xcrun, [["sourcekit-lsp"], ["sourcekit-lsp", "--stdio"]], root);
 }
 
+// Ruby server resolution
+function resolveRubyServer(): string {
+  try {
+    const settingsPath = path.join(os.homedir(), ".pi", "agent", "settings.json");
+    if (fs.existsSync(settingsPath)) {
+      const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+      const rubyServer = settings?.lsp?.rubyServer;
+      if (typeof rubyServer === "string" && rubyServer) return rubyServer;
+    }
+  } catch {
+    // ignore
+  }
+
+  return "ruby-lsp";
+}
+
 // Server Configs
 export const LSP_SERVERS: LSPServerConfig[] = [
   {
@@ -414,6 +431,17 @@ export const LSP_SERVERS: LSPServerConfig[] = [
     },
   },
   { id: "rust-analyzer", extensions: [".rs"], findRoot: (f, cwd) => findRoot(f, cwd, ["Cargo.toml"]), spawn: simpleSpawn("rust-analyzer", []) },
+  {
+    id: "ruby",
+    extensions: [".rb", ".rake", ".gemspec", ".ru"],
+    findRoot: (f, cwd) => findRoot(f, cwd, ["Gemfile", ".ruby-version"]),
+    spawn: async (root) => {
+      const isRubocop = resolveRubyServer() === "rubocop";
+      const bin = which(isRubocop ? "rubocop" : "ruby-lsp");
+      if (!bin) return undefined;
+      return { process: spawn(bin, isRubocop ? ["--lsp"] : [], { cwd: root, stdio: ["pipe", "pipe", "pipe"] }) };
+    },
+  },
 ];
 
 // Singleton Manager
@@ -497,7 +525,7 @@ export class LSPManager {
       const reader = new StreamMessageReader(handle.process.stdout!);
       const writer = new StreamMessageWriter(handle.process.stdin!);
       const conn = createMessageConnection(reader, writer);
-      
+
       // Prevent crashes from stream errors
       handle.process.stdin?.on("error", () => {});
       handle.process.stdout?.on("error", () => {});
@@ -1022,11 +1050,11 @@ export class LSPManager {
     const l = await this.loadFile(fp);
     if (!l) return [];
     await this.openOrUpdate(l.clients, l.absPath, l.uri, l.langId, l.content);
-    
+
     const start = this.toPos(startLine, startCol);
     const end = this.toPos(endLine ?? startLine, endCol ?? startCol);
     const range = { start, end };
-    
+
     // Get diagnostics for this range to include in context
     const diagnostics: Diagnostic[] = [];
     for (const c of l.clients) {
@@ -1035,7 +1063,7 @@ export class LSPManager {
         if (this.rangesOverlap(d.range, range)) diagnostics.push(d);
       }
     }
-    
+
     const results = await Promise.all(l.clients.map(async c => {
       if (c.closed) return [];
       try {
@@ -1050,7 +1078,7 @@ export class LSPManager {
     return results.flat();
   }
 
-  private rangesOverlap(a: { start: { line: number; character: number }; end: { line: number; character: number } }, 
+  private rangesOverlap(a: { start: { line: number; character: number }; end: { line: number; character: number } },
                         b: { start: { line: number; character: number }; end: { line: number; character: number } }): boolean {
     if (a.end.line < b.start.line || b.end.line < a.start.line) return false;
     if (a.end.line === b.start.line && a.end.character < b.start.character) return false;

--- a/lsp/lsp-tool.ts
+++ b/lsp/lsp-tool.ts
@@ -16,6 +16,7 @@
  *   - Kotlin (kotlin-ls)
  *   - Swift (sourcekit-lsp)
  *   - Rust (rust-analyzer)
+ *   - Ruby (ruby-lsp or rubocop)
  *
  * Usage:
  *   pi --extension ./lsp-tool.ts
@@ -182,7 +183,7 @@ function collectSymbols(symbols: any[], depth = 0, lines: string[] = [], query?:
 
 function formatWorkspaceEdit(edit: any, cwd?: string): string {
   const lines: string[] = [];
-  
+
   if (edit.documentChanges?.length) {
     for (const change of edit.documentChanges) {
       if (change.textDocument?.uri) {
@@ -196,7 +197,7 @@ function formatWorkspaceEdit(edit: any, cwd?: string): string {
       }
     }
   }
-  
+
   if (edit.changes) {
     for (const [uri, edits] of Object.entries(edit.changes)) {
       const fp = uriToPath(uri);
@@ -208,7 +209,7 @@ function formatWorkspaceEdit(edit: any, cwd?: string): string {
       }
     }
   }
-  
+
   return lines.length ? lines.join("\n") : "No edits.";
 }
 

--- a/lsp/lsp.ts
+++ b/lsp/lsp.ts
@@ -52,6 +52,7 @@ const WARMUP_MAP: Record<string, string> = {
   "gradlew": ".kt",
   "gradle.properties": ".kt",
   "Package.swift": ".swift",
+  "Gemfile": ".rb",
 };
 
 const MODE_LABELS: Record<HookMode, string> = {

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lsp-pi",
   "version": "1.0.3",
-  "description": "LSP extension for pi-coding-agent - provides language server tool and diagnostics feedback for Dart/Flutter, TypeScript, Vue, Svelte, Python, Go, Kotlin, Swift, Rust",
+  "description": "LSP extension for pi-coding-agent - provides language server tool and diagnostics feedback for Dart/Flutter, TypeScript, Vue, Svelte, Python, Go, Kotlin, Swift, Rust, Ruby",
   "scripts": {
     "test": "npx tsx tests/lsp.test.ts",
     "test:tool": "npx tsx tests/index.test.ts",
@@ -21,6 +21,7 @@
     "kotlin",
     "swift",
     "rust",
+    "ruby",
     "pi-coding-agent",
     "extension",
     "pi-package"

--- a/lsp/tests/lsp-integration.test.ts
+++ b/lsp/tests/lsp-integration.test.ts
@@ -436,6 +436,71 @@ result = greet(x)
 });
 
 // ============================================================================
+// Ruby
+// ============================================================================
+
+test("ruby: detects syntax errors", async () => {
+  if (!commandExists("ruby-lsp")) {
+    skip("ruby-lsp not installed");
+  }
+
+  const dir = await mkdtemp(join(tmpdir(), "lsp-ruby-"));
+  const manager = new LSPManager(dir);
+
+  try {
+    // Gemfile.lock is required for ruby-lsp to start
+    await writeFile(join(dir, "Gemfile"), 'source "https://rubygems.org"');
+    await writeFile(join(dir, "Gemfile.lock"), "GEM\n  remote: https://rubygems.org/\n  specs:\n\nPLATFORMS\n  ruby\n\nDEPENDENCIES\n\nBUNDLED WITH\n   2.5.0\n");
+
+    const file = join(dir, "main.rb");
+    // Syntax error: missing closing parenthesis
+    await writeFile(file, `
+def greet(name
+  puts "Hello, #{name}"
+end
+`);
+
+    const { diagnostics } = await manager.touchFileAndWait(file, 20000);
+
+    assert(diagnostics.length > 0, `Expected errors, got ${diagnostics.length}`);
+  } finally {
+    await manager.shutdown();
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("ruby: valid code has no errors", async () => {
+  if (!commandExists("ruby-lsp")) {
+    skip("ruby-lsp not installed");
+  }
+
+  const dir = await mkdtemp(join(tmpdir(), "lsp-ruby-"));
+  const manager = new LSPManager(dir);
+
+  try {
+    await writeFile(join(dir, "Gemfile"), 'source "https://rubygems.org"');
+    await writeFile(join(dir, "Gemfile.lock"), "GEM\n  remote: https://rubygems.org/\n  specs:\n\nPLATFORMS\n  ruby\n\nDEPENDENCIES\n\nBUNDLED WITH\n   2.5.0\n");
+
+    const file = join(dir, "main.rb");
+    await writeFile(file, `
+def greet(name)
+  puts "Hello, #{name}"
+end
+
+greet("world")
+`);
+
+    const { diagnostics } = await manager.touchFileAndWait(file, 20000);
+    const errors = diagnostics.filter(d => d.severity === 1);
+
+    assert(errors.length === 0, `Expected no errors, got: ${errors.map(d => d.message).join(", ")}`);
+  } finally {
+    await manager.shutdown();
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+// ============================================================================
 // Rename (TypeScript)
 // ============================================================================
 

--- a/lsp/tests/lsp.test.ts
+++ b/lsp/tests/lsp.test.ts
@@ -534,6 +534,44 @@ test("svelte: finds root with svelte.config.js", async () => {
 });
 
 // ============================================================================
+// Ruby root detection tests
+// ============================================================================
+
+test("ruby: finds root with Gemfile", async () => {
+  await withTempDir({
+    "Gemfile": 'source "https://rubygems.org"',
+    "app/models/user.rb": "class User; end",
+  }, async (dir) => {
+    const server = LSP_SERVERS.find(s => s.id === "ruby")!;
+    const root = server.findRoot(join(dir, "app/models/user.rb"), dir);
+    assertEquals(root, dir, "Should find root at Gemfile location");
+  });
+});
+
+test("ruby: finds root with .ruby-version", async () => {
+  await withTempDir({
+    ".ruby-version": "3.3.0",
+    "lib/my_gem.rb": "module MyGem; end",
+  }, async (dir) => {
+    const server = LSP_SERVERS.find(s => s.id === "ruby")!;
+    const root = server.findRoot(join(dir, "lib/my_gem.rb"), dir);
+    assertEquals(root, dir, "Should find root at .ruby-version location");
+  });
+});
+
+test("ruby: nested gem in monorepo finds nearest root", async () => {
+  await withTempDir({
+    "Gemfile": 'source "https://rubygems.org"',
+    "gems/auth/Gemfile": 'source "https://rubygems.org"',
+    "gems/auth/lib/auth.rb": "module Auth; end",
+  }, async (dir) => {
+    const server = LSP_SERVERS.find(s => s.id === "ruby")!;
+    const root = server.findRoot(join(dir, "gems/auth/lib/auth.rb"), dir);
+    assertEquals(root, join(dir, "gems/auth"), "Should find nearest Gemfile");
+  });
+});
+
+// ============================================================================
 // Additional Rust tests (parity with TypeScript)
 // ============================================================================
 
@@ -793,6 +831,53 @@ test("svelte: returns undefined when no config", async () => {
     const server = LSP_SERVERS.find(s => s.id === "svelte")!;
     const root = server.findRoot(join(dir, "App.svelte"), dir);
     assertEquals(root, undefined, "Should return undefined when no package.json or svelte.config.js");
+  });
+});
+
+// ============================================================================
+// Additional Ruby tests (parity with TypeScript)
+// ============================================================================
+
+test("LANGUAGE_IDS: Ruby extensions", async () => {
+  assertEquals(LANGUAGE_IDS[".rb"], "ruby", ".rb should map to ruby");
+  assertEquals(LANGUAGE_IDS[".rake"], "ruby", ".rake should map to ruby");
+  assertEquals(LANGUAGE_IDS[".gemspec"], "ruby", ".gemspec should map to ruby");
+  assertEquals(LANGUAGE_IDS[".ru"], "ruby", ".ru should map to ruby");
+});
+
+test("LSP_SERVERS: has Ruby server", async () => {
+  const server = LSP_SERVERS.find(s => s.id === "ruby");
+  assert(server !== undefined, "Should have ruby server");
+  assertIncludes(server!.extensions, ".rb", "Should handle .rb");
+  assertIncludes(server!.extensions, ".rake", "Should handle .rake");
+  assertIncludes(server!.extensions, ".gemspec", "Should handle .gemspec");
+  assertIncludes(server!.extensions, ".ru", "Should handle .ru");
+});
+
+test("ruby: returns undefined when no marker files", async () => {
+  await withTempDir({
+    "script.rb": "puts 'hello'",
+  }, async (dir) => {
+    const server = LSP_SERVERS.find(s => s.id === "ruby")!;
+    const root = server.findRoot(join(dir, "script.rb"), dir);
+    assertEquals(root, undefined, "Should return undefined when no Gemfile or .ruby-version");
+  });
+});
+
+test("ruby: Rails project finds root", async () => {
+  await withTempDir({
+    "Gemfile": 'gem "rails"',
+    "app/models/user.rb": "class User < ApplicationRecord; end",
+    "app/controllers/users_controller.rb": "class UsersController < ApplicationController; end",
+    "config/routes.rb": "Rails.application.routes.draw {}",
+  }, async (dir) => {
+    const server = LSP_SERVERS.find(s => s.id === "ruby")!;
+    const modelRoot = server.findRoot(join(dir, "app/models/user.rb"), dir);
+    const controllerRoot = server.findRoot(join(dir, "app/controllers/users_controller.rb"), dir);
+    const configRoot = server.findRoot(join(dir, "config/routes.rb"), dir);
+    assertEquals(modelRoot, dir, "Model should find root");
+    assertEquals(controllerRoot, dir, "Controller should find root");
+    assertEquals(configRoot, dir, "Config should find root");
   });
 });
 


### PR DESCRIPTION
Add Ruby language server support to the LSP extension.

## Changes

- Default server: `ruby-lsp` (Shopify) — full IDE features (diagnostics, definitions, symbols, hover, references, code actions, rename, formatting) with integrated RuboCop support
- Configurable via `lsp.rubyServer` in `~/.pi/agent/settings.json` (`"ruby-lsp"` or `"rubocop"`)
- File extensions: `.rb`, `.rake`, `.gemspec`, `.ru`
- Root detection: `Gemfile`, `.ruby-version`
- Warmup on session start for Ruby projects
- 7 new unit tests for root detection, language IDs, and server config

## Files changed

- `lsp-core.ts` — Ruby language IDs, server config, `resolveRubyServer()` settings reader
- `lsp.ts` — Gemfile warmup marker
- `lsp-tool.ts` — updated supported languages comment
- `package.json` — updated description and keywords
- `README.md` — Ruby in languages table, install instructions, server selection docs under Settings
- `tests/lsp.test.ts` — Ruby root detection and parity tests
