### PR TITLE
fix(lsp): use selectionRange instead of range for symbol position display

### DIFF
--- a/lsp/lsp-core.ts
+++ b/lsp/lsp-core.ts
@@ -1127,3 +1127,26 @@ export async function resolvePosition(manager: LSPManager, file: string, query: 
   const pos = findSymbolPosition(symbols, query);
   return pos ? { line: pos.line + 1, column: pos.character + 1 } : null;
 }
+
+/**
+ * Format a list of document symbols into display lines.
+ *
+ * Uses `selectionRange` (the identifier's own range) rather than `range` (the
+ * full declaration span) so that the reported line:column points at the symbol
+ * name itself — the position that hover, definition, and references requests
+ * all expect.  Falls back to `range` for servers that omit `selectionRange`.
+ */
+export function collectSymbols(symbols: DocumentSymbol[], depth = 0, lines: string[] = [], query?: string): string[] {
+  for (const sym of symbols) {
+    const name = (sym as any)?.name ?? "<unknown>";
+    if (query && !name.toLowerCase().includes(query.toLowerCase())) {
+      if ((sym as any).children?.length) collectSymbols((sym as any).children, depth + 1, lines, query);
+      continue;
+    }
+    const startPos = sym?.selectionRange?.start ?? sym?.range?.start;
+    const loc = startPos ? `${startPos.line + 1}:${startPos.character + 1}` : "";
+    lines.push(`${"  ".repeat(depth)}${name}${loc ? ` (${loc})` : ""}`);
+    if ((sym as any).children?.length) collectSymbols((sym as any).children, depth + 1, lines, query);
+  }
+  return lines;
+}

--- a/lsp/lsp-tool.ts
+++ b/lsp/lsp-tool.ts
@@ -28,7 +28,7 @@ import { Type, type Static } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
-import { getOrCreateManager, formatDiagnostic, filterDiagnosticsBySeverity, uriToPath, resolvePosition, type SeverityFilter } from "./lsp-core.js";
+import { getOrCreateManager, formatDiagnostic, filterDiagnosticsBySeverity, uriToPath, resolvePosition, collectSymbols, type SeverityFilter } from "./lsp-core.js";
 
 const PREVIEW_LINES = 10;
 
@@ -166,19 +166,6 @@ function formatSignature(help: any): string {
   return text;
 }
 
-function collectSymbols(symbols: any[], depth = 0, lines: string[] = [], query?: string): string[] {
-  for (const sym of symbols) {
-    const name = sym?.name ?? "<unknown>";
-    if (query && !name.toLowerCase().includes(query.toLowerCase())) {
-      if (sym.children?.length) collectSymbols(sym.children, depth + 1, lines, query);
-      continue;
-    }
-    const loc = sym?.range?.start ? `${sym.range.start.line + 1}:${sym.range.start.character + 1}` : "";
-    lines.push(`${"  ".repeat(depth)}${name}${loc ? ` (${loc})` : ""}`);
-    if (sym.children?.length) collectSymbols(sym.children, depth + 1, lines, query);
-  }
-  return lines;
-}
 
 function formatWorkspaceEdit(edit: any, cwd?: string): string {
   const lines: string[] = [];

--- a/lsp/tests/index.test.ts
+++ b/lsp/tests/index.test.ts
@@ -24,7 +24,7 @@ function assertEqual<T>(actual: T, expected: T, message?: string) {
 // Or we can extract and test the logic directly
 // ============================================================================
 
-import { uriToPath, findSymbolPosition, formatDiagnostic, filterDiagnosticsBySeverity } from "../lsp-core.js";
+import { uriToPath, findSymbolPosition, formatDiagnostic, filterDiagnosticsBySeverity, collectSymbols } from "../lsp-core.js";
 
 // ============================================================================
 // uriToPath tests
@@ -200,6 +200,80 @@ test("filterDiagnosticsBySeverity: info returns errors, warnings, and info", () 
   ];
   const result = filterDiagnosticsBySeverity(diags as any, "info");
   assertEqual(result.length, 3);
+});
+
+// ============================================================================
+// collectSymbols tests
+// ============================================================================
+
+test("collectSymbols: uses selectionRange start for reported position", () => {
+  // selectionRange.start (character 5) differs from range.start (character 0)
+  const symbols = [
+    { name: "foo", kind: 12, range: { start: { line: 0, character: 0 }, end: { line: 2, character: 0 } }, selectionRange: { start: { line: 0, character: 5 }, end: { line: 0, character: 8 } }, children: [] },
+  ];
+  const lines = collectSymbols(symbols as any);
+  assertEqual(lines[0], "foo (1:6)");
+});
+
+test("collectSymbols: falls back to range when selectionRange is absent", () => {
+  const symbols = [
+    { name: "foo", kind: 12, range: { start: { line: 0, character: 3 }, end: { line: 0, character: 6 } }, children: [] },
+  ];
+  const lines = collectSymbols(symbols as any);
+  assertEqual(lines[0], "foo (1:4)");
+});
+
+test("collectSymbols: converts 0-indexed positions to 1-indexed", () => {
+  const symbols = [
+    { name: "foo", kind: 12, range: { start: { line: 4, character: 0 }, end: { line: 4, character: 3 } }, selectionRange: { start: { line: 4, character: 0 }, end: { line: 4, character: 3 } }, children: [] },
+  ];
+  const lines = collectSymbols(symbols as any);
+  assertEqual(lines[0], "foo (5:1)");
+});
+
+test("collectSymbols: formats multiple symbols in order", () => {
+  const symbols = [
+    { name: "bar", kind: 12, range: { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } }, selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } }, children: [] },
+    { name: "baz", kind: 12, range: { start: { line: 5, character: 0 }, end: { line: 5, character: 3 } }, selectionRange: { start: { line: 5, character: 0 }, end: { line: 5, character: 3 } }, children: [] },
+  ];
+  const lines = collectSymbols(symbols as any);
+  assertEqual(lines.length, 2);
+  assertEqual(lines[0], "bar (1:1)");
+  assertEqual(lines[1], "baz (6:1)");
+});
+
+test("collectSymbols: filters by query (case-insensitive)", () => {
+  const symbols = [
+    { name: "foo", kind: 12, range: { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } }, selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } }, children: [] },
+    { name: "fooBar", kind: 12, range: { start: { line: 1, character: 0 }, end: { line: 1, character: 6 } }, selectionRange: { start: { line: 1, character: 0 }, end: { line: 1, character: 6 } }, children: [] },
+    { name: "baz", kind: 12, range: { start: { line: 2, character: 0 }, end: { line: 2, character: 3 } }, selectionRange: { start: { line: 2, character: 0 }, end: { line: 2, character: 3 } }, children: [] },
+  ];
+  const lines = collectSymbols(symbols as any, 0, [], "FOO");
+  assertEqual(lines.length, 2);
+  assertEqual(lines[0], "foo (1:1)");
+  assertEqual(lines[1], "fooBar (2:1)");
+});
+
+test("collectSymbols: recurses into children with indentation", () => {
+  const symbols = [
+    {
+      name: "MyStruct", kind: 23,
+      range: { start: { line: 0, character: 0 }, end: { line: 5, character: 0 } },
+      selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 8 } },
+      children: [
+        { name: "field", kind: 8, range: { start: { line: 1, character: 2 }, end: { line: 1, character: 7 } }, selectionRange: { start: { line: 1, character: 2 }, end: { line: 1, character: 7 } }, children: [] },
+      ],
+    },
+  ];
+  const lines = collectSymbols(symbols as any);
+  assertEqual(lines.length, 2);
+  assertEqual(lines[0], "MyStruct (1:1)");
+  assertEqual(lines[1], "  field (2:3)");
+});
+
+test("collectSymbols: returns empty array for no symbols", () => {
+  const lines = collectSymbols([] as any);
+  assertEqual(lines.length, 0);
 });
 
 // ============================================================================


### PR DESCRIPTION
## Problem

The `symbols` action was reporting wrong line:column positions for symbols. Function declarations always showed column 1 regardless of where the name actually appeared, which caused query-based hover, definition, and references to point at the wrong position and return no results.

## Root cause

`collectSymbols()` in `lsp-tool.ts` was reading `sym.range.start` to build the displayed position. The LSP spec defines two distinct fields on `DocumentSymbol`:

| Field | Meaning |
|-------|---------|
| `range` | Full span of the declaration, starting at the keyword (`func`, `type`, etc.) |
| `selectionRange` | Span of the identifier name itself |

The companion function `findSymbolPosition()` in `lsp-core.ts` already used `selectionRange` correctly — only the display path was wrong.

## Changes

- **`lsp/lsp-core.ts`** — move `collectSymbols()` here as an exported utility alongside `findSymbolPosition()`, fix it to use `selectionRange.start` with a fallback to `range.start`
- **`lsp/lsp-tool.ts`** — import `collectSymbols` from core, remove the local copy
- **`lsp/tests/index.test.ts`** — add 7 tests for `collectSymbols` following the existing patterns in the file

## Testing

```
npm run test:tool   →  25 passed, 0 failed
npm test            →  69 passed, 0 failed
```