### PR TITLE
feat(lsp): add workspace-symbols and workspace-references actions

### DIFF
--- a/lsp/README.md
+++ b/lsp/README.md
@@ -100,6 +100,8 @@ The `lsp` tool provides these actions:
 | `signature` | Get function signature | `file` + (`line`/`column` or `query`) |
 | `rename` | Rename symbol across files | `file` + (`line`/`column` or `query`) + `newName` |
 | `codeAction` | Get available quick fixes/refactors | `file` + `line`/`column`, optional `endLine`/`endColumn` |
+| `workspace-symbols` | Search for symbols across the workspace by name | `query`, optional `file` to scope by language |
+| `workspace-references` | Find all references to a symbol across the workspace by name | `query`, optional `file` to scope by language |
 
 **Query resolution**: For position-based actions, you can provide a `query` (symbol name) instead of `line`/`column`. The tool will find the symbol in the file and use its position.
 
@@ -129,6 +131,8 @@ Example questions the LLM can answer using this tool:
 - "Get only errors from `index.ts`"
 - "Rename `oldFunction` to `newFunction`"
 - "What quick fixes are available at line 10?"
+- "Find all symbols named `Manager` across the workspace"
+- "Where is `formatDiagnostic` used across the entire project?"
 
 ## Settings
 

--- a/lsp/lsp-core.ts
+++ b/lsp/lsp-core.ts
@@ -27,6 +27,7 @@ import {
   DocumentSymbolRequest,
   RenameRequest,
   CodeActionRequest,
+  WorkspaceSymbolRequest,
 } from "vscode-languageserver-protocol/node.js";
 import {
   type Diagnostic,
@@ -39,6 +40,7 @@ import {
   type WorkspaceEdit,
   type CodeAction,
   type Command,
+  type WorkspaceSymbol,
   DiagnosticSeverity,
   CodeActionKind,
   DocumentDiagnosticReportKind,
@@ -997,6 +999,67 @@ export class LSPManager {
       catch { return []; }
     }));
     return results.flat();
+  }
+
+  async getWorkspaceSymbols(query: string, filePath?: string): Promise<SymbolInformation[]> {
+    // If filePath given, scope to clients for that file's language
+    // Otherwise query ALL active clients
+    let clients: LSPClient[];
+    if (filePath) {
+      const absPath = this.resolve(filePath);
+      clients = await this.getClientsForFile(absPath);
+    } else {
+      clients = Array.from(this.clients.values());
+    }
+    if (!clients.length) return [];
+
+    const results = await Promise.all(clients.map(async c => {
+      if (c.closed) return [];
+      // Check if server supports workspace symbols
+      if (!c.capabilities?.workspaceSymbolProvider) return [];
+      try {
+        const result = await c.connection.sendRequest(WorkspaceSymbolRequest.type, { query });
+        if (!result) return [];
+        // Normalize: result can be SymbolInformation[] or WorkspaceSymbol[]
+        return (result as SymbolInformation[]);
+      } catch { return []; }
+    }));
+    return results.flat();
+  }
+
+  async getWorkspaceReferences(query: string, filePath?: string): Promise<{ symbol: SymbolInformation; references: Location[] }[]> {
+    const symbols = await this.getWorkspaceSymbols(query, filePath);
+    if (!symbols.length) return [];
+
+    // Limit to first 10 matches to avoid performance issues
+    const MAX_SYMBOL_LOOKUPS = 10;
+    const toQuery = symbols.slice(0, MAX_SYMBOL_LOOKUPS);
+
+    // Deduplicate symbols by location (same uri + line)
+    const seen = new Set<string>();
+    const unique: SymbolInformation[] = [];
+    for (const sym of toQuery) {
+      const key = `${sym.location.uri}:${sym.location.range.start.line}:${sym.location.range.start.character}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      unique.push(sym);
+    }
+
+    const results: { symbol: SymbolInformation; references: Location[] }[] = [];
+
+    for (const sym of unique) {
+      const fp = uriToPath(sym.location.uri);
+      const line = sym.location.range.start.line + 1; // convert to 1-indexed
+      const col = sym.location.range.start.character + 1;
+      try {
+        const refs = await this.getReferences(fp, line, col);
+        results.push({ symbol: sym, references: refs });
+      } catch {
+        // Skip symbols we can't get references for
+      }
+    }
+
+    return results;
   }
 
   async rename(fp: string, line: number, col: number, newName: string): Promise<WorkspaceEdit | null> {

--- a/lsp/lsp-tool.ts
+++ b/lsp/lsp-tool.ts
@@ -42,7 +42,7 @@ function diagnosticsWaitMsForFile(filePath: string): number {
   return DIAGNOSTICS_WAIT_MS_DEFAULT;
 }
 
-const ACTIONS = ["definition", "references", "hover", "symbols", "diagnostics", "workspace-diagnostics", "signature", "rename", "codeAction"] as const;
+const ACTIONS = ["definition", "references", "hover", "symbols", "diagnostics", "workspace-diagnostics", "signature", "rename", "codeAction", "workspace-symbols", "workspace-references"] as const;
 const SEVERITY_FILTERS = ["all", "error", "warning", "info", "hint"] as const;
 
 const LspParams = Type.Object({
@@ -147,6 +147,18 @@ function formatLocation(loc: { uri: string; range?: { start?: { line: number; ch
   return typeof line === "number" && typeof col === "number" ? `${display}:${line + 1}:${col + 1}` : display;
 }
 
+function symbolKindName(kind: number): string {
+  const names: Record<number, string> = {
+    1: "File", 2: "Module", 3: "Namespace", 4: "Package", 5: "Class",
+    6: "Method", 7: "Property", 8: "Field", 9: "Constructor", 10: "Enum",
+    11: "Interface", 12: "Function", 13: "Variable", 14: "Constant",
+    15: "String", 16: "Number", 17: "Boolean", 18: "Array", 19: "Object",
+    20: "Key", 21: "Null", 22: "EnumMember", 23: "Struct", 24: "Event",
+    25: "Operator", 26: "TypeParameter",
+  };
+  return names[kind] || "Symbol";
+}
+
 function formatHover(contents: unknown): string {
   if (typeof contents === "string") return contents;
   if (Array.isArray(contents)) return contents.map(c => typeof c === "string" ? c : (c as any)?.value ?? "").filter(Boolean).join("\n\n");
@@ -215,6 +227,7 @@ export default function (pi: ExtensionAPI) {
     description: `Query language server for definitions, references, types, symbols, diagnostics, rename, and code actions.
 
 Actions: definition, references, hover, signature, rename (require file + line/column or query), symbols (file, optional query), diagnostics (file), workspace-diagnostics (files array), codeAction (file + position).
+workspace-symbols (query, optional file to scope language), workspace-references (query, optional file to scope language).
 Use bash to find files: find src -name "*.ts" -type f`,
     parameters: LspParams,
 
@@ -315,6 +328,32 @@ Use bash to find files: find src -name "*.ts" -type f`,
             const result = await abortable(manager.getCodeActions(file!, rLine!, rCol!, endLine, endColumn), signal);
             const actions = formatCodeActions(result);
             return { content: [{ type: "text", text: `action: codeAction\n${qLine}${posLine}${actions.length ? actions.join("\n") : "No code actions available."}` }], details: result };
+          }
+          case "workspace-symbols": {
+            if (!query) throw new Error('Action "workspace-symbols" requires a "query" parameter.');
+            const results = await abortable(manager.getWorkspaceSymbols(query, file || undefined), signal);
+            const lines = results.map(s => {
+              const loc = formatLocation(s.location, ctx?.cwd);
+              const kind = symbolKindName(s.kind);
+              return `${loc} ${s.name} (${kind})`;
+            });
+            return { content: [{ type: "text", text: `action: workspace-symbols\n${qLine}${lines.length ? lines.join("\n") : "No symbols found."}` }], details: results };
+          }
+          case "workspace-references": {
+            if (!query) throw new Error('Action "workspace-references" requires a "query" parameter.');
+            const results = await abortable(manager.getWorkspaceReferences(query, file || undefined), signal);
+            const lines: string[] = [];
+            const allRefs: any[] = [];
+            for (const { symbol, references } of results) {
+              const symLoc = formatLocation(symbol.location, ctx?.cwd);
+              const kind = symbolKindName(symbol.kind);
+              lines.push(`${symbol.name} (${kind}) defined at ${symLoc}:`);
+              for (const ref of references) {
+                lines.push(`  ${formatLocation(ref, ctx?.cwd)}`);
+                allRefs.push(ref);
+              }
+            }
+            return { content: [{ type: "text", text: `action: workspace-references\n${qLine}${lines.length ? lines.join("\n") : "No references found."}` }], details: allRefs };
           }
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

Add two new LSP tool actions for cross-file symbol search and reference finding.

### New Actions

| Action | Description | Parameters |
|--------|-------------|------------|
| `workspace-symbols` | Search for symbols across the entire workspace by name | `query` (required), `file` (optional, to scope by language) |
| `workspace-references` | Find all references to a symbol across the workspace by name | `query` (required), `file` (optional, to scope by language) |

### How it works

**`workspace-symbols`** sends the LSP `workspace/symbol` request to all active language servers (or scoped to a specific language if `file` is provided). Returns symbol definitions with their locations and kinds.

**`workspace-references`** chains two LSP calls:
1. `workspace/symbol` to find matching symbol definitions across the workspace
2. `textDocument/references` at each definition location to collect all usages

This enables finding all cross-file references to a symbol by name alone, without needing to know which file contains it.

### Implementation details

- Checks `workspaceSymbolProvider` capability before querying each server
- Deduplicates symbols by location (uri + line + character)
- Limits reference lookups to 10 symbol matches for performance
- Gracefully returns empty results for unsupported servers
- Includes `symbolKindName` helper for human-readable symbol kind display

### Files changed

- **lsp-core.ts**: Added `getWorkspaceSymbols()` and `getWorkspaceReferences()` methods to `LSPManager`
- **lsp-tool.ts**: Added `workspace-symbols` and `workspace-references` action handlers, `symbolKindName` helper, updated ACTIONS and tool description
- **README.md**: Documented new actions in the tool table and added example questions

### Testing

- All 94 existing tests pass (69 LSP tests + 25 unit tests)
- TypeScript compilation clean (`tsc --noEmit` passes)