### PR TITLE
fix(lsp): import protocol node entry via subpath export (supports 3.18+)

### DIFF
--- a/lsp/lsp-core.ts
+++ b/lsp/lsp-core.ts
@@ -27,7 +27,7 @@ import {
   DocumentSymbolRequest,
   RenameRequest,
   CodeActionRequest,
-} from "vscode-languageserver-protocol/node.js";
+} from "vscode-languageserver-protocol/node";
 import {
   type Diagnostic,
   type Location,

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "vscode-languageserver-protocol": "^3.17.5"
+    "vscode-languageserver-protocol": "^3.18.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",


### PR DESCRIPTION
## Summary

`vscode-languageserver-protocol@3.18` introduced an `exports` map that only exposes the node entry point under the `./node` subpath. The LSP extension imported it as `vscode-languageserver-protocol/node.js`, which is not a key in that map, so under 3.18+ Node/Bun refuses to resolve it and the extension fails to load:

`Error: Cannot find module 'vscode-languageserver-protocol/node.js'`

The dependency range is `^3.17.5`, so a fresh install pulls 3.18.x and hits this immediately.

## Changes

- Import the node entry via the `/node` subpath in `lsp/lsp-core.ts`. This resolves under both 3.17.x (no exports map — both `/node` and `/node.js` work) and 3.18+ (exports map — only `/node` works).
- Bump `vscode-languageserver-protocol` to `^3.18.0`.

## Testing

- Verified `require.resolve("vscode-languageserver-protocol/node")` succeeds against both 3.17.5 and 3.18.2, while `/node.js` fails under 3.18.
- `tsc --noEmit`: the pre-existing baseline error `Cannot find module '.../node.js'` in `lsp-core.ts` is gone after the change. (A few unrelated type errors in `lsp.ts` exist on `main` and are unchanged by this PR.)
