### PR TITLE
feat(lsp): add safe declarative server config

### DIFF
--- a/lsp/README.md
+++ b/lsp/README.md
@@ -8,19 +8,20 @@ Language Server Protocol integration for pi-coding-agent.
 - **Tool** (`lsp-tool.ts`): On-demand LSP queries (definitions, references, hover, symbols, diagnostics, signatures)
 - Manages one LSP server per project root and reuses them across turns
 - **Efficient**: Bounded memory usage via LRU cache and idle file cleanup
-- Supports TypeScript/JavaScript, Vue, Svelte, Dart/Flutter, Python, Go, Kotlin, Swift, and Rust
+- Supports TypeScript/JavaScript, C/C++, Vue, Svelte, Dart/Flutter, Python, Go, Kotlin, Swift, and Rust
 
 ## Supported Languages
 
 | Language | Server | Detection |
 |----------|--------|-----------|
-| TypeScript/JavaScript | `typescript-language-server` | `package.json`, `tsconfig.json` |
+| TypeScript/JavaScript | `typescript-language-server` | `package.json`, `tsconfig.json`, `jsconfig.json` |
+| C/C++ | `clangd --background-index` | nearest `compile_commands.json`, `.clangd`, `CMakeLists.txt` |
 | Vue | `vue-language-server` | `package.json`, `vite.config.ts` |
 | Svelte | `svelteserver` | `svelte.config.js` |
 | Dart/Flutter | `dart language-server` | `pubspec.yaml` |
 | Python | `pyright-langserver` | `pyproject.toml`, `requirements.txt` |
 | Go | `gopls` | `go.mod` |
-| Kotlin | `kotlin-ls` | `settings.gradle(.kts)`, `build.gradle(.kts)`, `pom.xml` |
+| Kotlin | `kotlin-lsp` (fallback: `kotlin-language-server`) | `settings.gradle(.kts)`, `build.gradle(.kts)`, `pom.xml` |
 | Swift | `sourcekit-lsp` | `Package.swift`, Xcode (`*.xcodeproj` / `*.xcworkspace`) |
 | Rust | `rust-analyzer` | `Cargo.toml` |
 
@@ -48,6 +49,9 @@ Install the language servers you need:
 # TypeScript/JavaScript
 npm i -g typescript-language-server typescript
 
+# C/C++
+# Install clangd from your platform's LLVM package.
+
 # Vue
 npm i -g @vue/language-server
 
@@ -60,7 +64,7 @@ npm i -g pyright
 # Go (install gopls via go install)
 go install golang.org/x/tools/gopls@latest
 
-# Kotlin (kotlin-ls)
+# Kotlin (kotlin-lsp)
 brew install JetBrains/utils/kotlin-lsp
 
 # Swift (sourcekit-lsp; macOS)
@@ -146,7 +150,54 @@ To disable auto diagnostics, choose "Disabled" in `/lsp` or set in `~/.pi/agent/
 ```
 Other values: `"agent_end"` (default) and `"edit_write"`.
 
-Agent-end mode analyzes files touched during the full agent response (after all tool calls complete) and posts a diagnostics message only once. Disabling the hook does not disable the `/lsp` tool.
+Agent-end mode analyzes files touched during the full agent response (after all tool calls complete) and posts a diagnostics message only once. Disabling the hook does not disable the model-facing `lsp` tool.
+
+### Language server configuration
+
+Builtins are the defaults. Optional JSON configuration is read from:
+
+- Global: `${PI_CODING_AGENT_DIR:-~/.pi/agent}/lsp.json`
+- Project: `.pi/lsp.json` (Pi's configured project directory name is used at runtime)
+
+Neither file is created automatically. The global file can override builtins or add servers:
+
+```json
+{
+  "servers": {
+    "clangd": {
+      "args": ["--background-index", "--clang-tidy"],
+      "diagnosticsWaitMs": 5000
+    },
+    "example-ls": {
+      "command": "example-language-server",
+      "args": ["--stdio"],
+      "extensions": [".example"],
+      "rootMarkers": ["example.toml"],
+      "languageIds": { ".example": "example" },
+      "initializationOptions": { "feature": true }
+    }
+  }
+}
+```
+
+Global server fields are `command`, `args`, `extensions`, `rootMarkers`, `languageIds`, `initializationOptions`, `diagnosticsWaitMs`, and `disabled`. A new server requires `command`, nonempty dot-prefixed `extensions`, and nonempty `rootMarkers`. Extensions and language-ID keys are normalized to lowercase. `command` must be a bare executable name resolved from `PATH` or an absolute path.
+
+Dart/Flutter, TypeScript, Kotlin, and Swift have builtin executable discovery or fallbacks. Overriding their `command` or `args` switches to the configured command directly; Pi reports a configuration warning when this happens.
+
+Project configuration is intentionally tuning-only. For an existing builtin or global server it may set only:
+
+```json
+{
+  "servers": {
+    "clangd": { "diagnosticsWaitMs": 10000 },
+    "rust-analyzer": { "disabled": true }
+  }
+}
+```
+
+A project cannot add a server, change its executable, arguments, extensions, roots, language IDs, or initialization options, and cannot re-enable a globally disabled server. `diagnosticsWaitMs` is clamped to 250–60000 ms. Invalid JSON or invalid entries are ignored without disabling builtins.
+
+**Safety model:** commands are spawned directly without a shell. Configuration never installs or downloads servers, runs installer commands, reads an environment-variable command map, or writes scaffolding. Prototype-pollution keys are rejected. Project restrictions apply regardless of project trust.
 
 ## File Structure
 
@@ -154,7 +205,8 @@ Agent-end mode analyzes files touched during the full agent response (after all 
 |------|---------|
 | `lsp.ts` | Hook extension (auto-diagnostics; default at agent end) |
 | `lsp-tool.ts` | Tool extension (on-demand LSP queries) |
-| `lsp-core.ts` | LSPManager class, server configs, singleton manager |
+| `lsp-core.ts` | LSPManager class, builtin server definitions, singleton manager |
+| `lsp-config.ts` | Safe global/project configuration resolver |
 | `package.json` | Declares both extensions via "pi" field |
 
 ## Testing

--- a/lsp/lsp-config.ts
+++ b/lsp/lsp-config.ts
@@ -1,0 +1,328 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export const MIN_DIAGNOSTICS_WAIT_MS = 250;
+export const MAX_DIAGNOSTICS_WAIT_MS = 60_000;
+export const MAX_CONFIG_BYTES = 256 * 1024;
+
+export function defaultGlobalLSPConfigPath(): string {
+  return path.join(
+    process.env.PI_CODING_AGENT_DIR ?? path.join(os.homedir(), ".pi", "agent"),
+    "lsp.json",
+  );
+}
+
+const FORBIDDEN_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+const GLOBAL_FIELDS = new Set([
+  "command", "args", "extensions", "rootMarkers", "languageIds",
+  "initializationOptions", "diagnosticsWaitMs", "disabled",
+]);
+const PROJECT_FIELDS = new Set(["diagnosticsWaitMs", "disabled"]);
+
+export interface LSPServerDefinition {
+  id: string;
+  command: string;
+  args: string[];
+  extensions: string[];
+  rootMarkers: string[];
+  languageIds: Record<string, string>;
+  initializationOptions?: Record<string, unknown>;
+  diagnosticsWaitMs: number;
+  disabled?: boolean;
+}
+
+export interface ResolvedLSPServerConfig extends LSPServerDefinition {
+  /** Fields changed by global config. Used to retain special builtin launch/root behavior when possible. */
+  globalOverrides: ReadonlySet<string>;
+  builtin: boolean;
+}
+
+export interface LSPConfigWarning {
+  path: string;
+  message: string;
+  server?: string;
+}
+
+export interface ResolveLSPConfigOptions {
+  cwd: string;
+  builtins: readonly LSPServerDefinition[];
+  configDirName?: string;
+  globalConfigPath?: string;
+  projectConfigPath?: string;
+}
+
+export interface LSPConfigResult {
+  servers: ResolvedLSPServerConfig[];
+  warnings: LSPConfigWarning[];
+}
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function ownEntries(value: JsonObject): Array<[string, unknown]> {
+  return Object.keys(value).map((key) => [key, value[key]]);
+}
+
+function safeClone(value: unknown): unknown | undefined {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (Array.isArray(value)) {
+    const result: unknown[] = [];
+    for (const item of value) {
+      const cloned = safeClone(item);
+      if (cloned === undefined) return undefined;
+      result.push(cloned);
+    }
+    return result;
+  }
+  if (!isObject(value)) return undefined;
+
+  const result = Object.create(null) as JsonObject;
+  for (const [key, item] of ownEntries(value)) {
+    if (FORBIDDEN_KEYS.has(key)) return undefined;
+    const cloned = safeClone(item);
+    if (cloned === undefined) return undefined;
+    result[key] = cloned;
+  }
+  return result;
+}
+
+function readConfig(filePath: string, warnings: LSPConfigWarning[]): JsonObject | undefined {
+  try {
+    if (!fs.existsSync(filePath)) return undefined;
+    if (fs.statSync(filePath).size > MAX_CONFIG_BYTES) {
+      throw new Error(`file exceeds ${MAX_CONFIG_BYTES} bytes`);
+    }
+    const parsed: unknown = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    if (!isObject(parsed)) throw new Error("top level must be an object");
+    return parsed;
+  } catch (error) {
+    warnings.push({ path: filePath, message: `Ignored malformed config: ${error instanceof Error ? error.message : String(error)}` });
+    return undefined;
+  }
+}
+
+function serverEntries(config: JsonObject, filePath: string, warnings: LSPConfigWarning[]): Array<[string, JsonObject]> {
+  for (const key of Object.keys(config)) {
+    if (FORBIDDEN_KEYS.has(key)) {
+      warnings.push({ path: filePath, message: `Ignored forbidden key: ${key}` });
+    } else if (key !== "servers") {
+      warnings.push({ path: filePath, message: `Ignored unknown top-level field: ${key}` });
+    }
+  }
+
+  const servers = config.servers;
+  if (servers === undefined) return [];
+  if (!isObject(servers)) {
+    warnings.push({ path: filePath, message: 'Ignored "servers": expected an object' });
+    return [];
+  }
+
+  const result: Array<[string, JsonObject]> = [];
+  for (const [id, value] of ownEntries(servers)) {
+    if (FORBIDDEN_KEYS.has(id)) {
+      warnings.push({ path: filePath, server: id, message: `Ignored forbidden server id: ${id}` });
+    } else if (!isObject(value)) {
+      warnings.push({ path: filePath, server: id, message: "Ignored server config: expected an object" });
+    } else {
+      result.push([id, value]);
+    }
+  }
+  return result;
+}
+
+function stringArray(value: unknown, nonempty: boolean): string[] | undefined {
+  if (!Array.isArray(value) || (nonempty && value.length === 0)) return undefined;
+  if (!value.every((item) => typeof item === "string" && item.length > 0)) return undefined;
+  return [...value];
+}
+
+function extensionArray(value: unknown): string[] | undefined {
+  const parsed = stringArray(value, true);
+  if (!parsed || parsed.some((extension) => !extension.startsWith("."))) return undefined;
+  return parsed.map((extension) => extension.toLowerCase());
+}
+
+export function isValidLSPCommand(command: string): boolean {
+  return path.isAbsolute(command) || (!command.includes("/") && !command.includes("\\") && command.length > 0);
+}
+
+export function clampDiagnosticsWaitMs(value: number): number {
+  return Math.max(MIN_DIAGNOSTICS_WAIT_MS, Math.min(MAX_DIAGNOSTICS_WAIT_MS, Math.round(value)));
+}
+
+function languageIds(value: unknown): Record<string, string> | undefined {
+  if (!isObject(value)) return undefined;
+  const result = Object.create(null) as Record<string, string>;
+  for (const [extension, id] of ownEntries(value)) {
+    if (FORBIDDEN_KEYS.has(extension) || !extension.startsWith(".") || typeof id !== "string" || id.length === 0) return undefined;
+    result[extension.toLowerCase()] = id;
+  }
+  return result;
+}
+
+function copyDefinition(definition: LSPServerDefinition, builtin: boolean): ResolvedLSPServerConfig {
+  return {
+    ...definition,
+    args: [...definition.args],
+    extensions: [...definition.extensions],
+    rootMarkers: [...definition.rootMarkers],
+    languageIds: { ...definition.languageIds },
+    initializationOptions: definition.initializationOptions
+      ? safeClone(definition.initializationOptions) as Record<string, unknown>
+      : undefined,
+    diagnosticsWaitMs: clampDiagnosticsWaitMs(definition.diagnosticsWaitMs),
+    disabled: definition.disabled === true,
+    globalOverrides: new Set(),
+    builtin,
+  };
+}
+
+function applyGlobalEntry(
+  id: string,
+  entry: JsonObject,
+  existing: ResolvedLSPServerConfig | undefined,
+  filePath: string,
+  warnings: LSPConfigWarning[],
+): ResolvedLSPServerConfig | undefined {
+  for (const key of Object.keys(entry)) {
+    if (FORBIDDEN_KEYS.has(key) || !GLOBAL_FIELDS.has(key)) {
+      warnings.push({ path: filePath, server: id, message: `Ignored unknown or forbidden field: ${key}` });
+    }
+  }
+
+  const isNew = !existing;
+  const command = entry.command;
+  const extensions = entry.extensions;
+  const rootMarkers = entry.rootMarkers;
+  if (isNew && (typeof command !== "string" || !isValidLSPCommand(command)
+    || !extensionArray(extensions) || !stringArray(rootMarkers, true))) {
+    warnings.push({ path: filePath, server: id, message: "Ignored new server: command, nonempty extensions, and nonempty rootMarkers are required" });
+    return undefined;
+  }
+
+  const next = existing
+    ? { ...copyDefinition(existing, existing.builtin), globalOverrides: new Set(existing.globalOverrides) }
+    : copyDefinition({
+      id,
+      command: command as string,
+      args: [],
+      extensions: extensionArray(extensions)!,
+      rootMarkers: stringArray(rootMarkers, true)!,
+      languageIds: {},
+      diagnosticsWaitMs: 3000,
+    }, false);
+  const overrides = new Set(next.globalOverrides);
+
+  const invalid = (field: string, expected: string) => {
+    warnings.push({ path: filePath, server: id, message: `Ignored invalid ${field}; expected ${expected}` });
+  };
+
+  for (const field of GLOBAL_FIELDS) {
+    if (!Object.prototype.hasOwnProperty.call(entry, field)) continue;
+    const value = entry[field];
+    switch (field) {
+      case "command":
+        if (typeof value === "string" && isValidLSPCommand(value)) { next.command = value; overrides.add(field); }
+        else invalid(field, "a bare executable name or absolute path");
+        break;
+      case "args": {
+        const parsed = stringArray(value, false);
+        if (parsed) { next.args = parsed; overrides.add(field); } else invalid(field, "an array of strings");
+        break;
+      }
+      case "extensions": {
+        const parsed = extensionArray(value);
+        if (parsed) { next.extensions = parsed; overrides.add(field); } else invalid(field, "a nonempty array of dot-prefixed extensions");
+        break;
+      }
+      case "rootMarkers": {
+        const parsed = stringArray(value, true);
+        if (parsed) { next.rootMarkers = parsed; overrides.add(field); } else invalid(field, "a nonempty array of strings");
+        break;
+      }
+      case "languageIds": {
+        const parsed = languageIds(value);
+        if (parsed) { next.languageIds = parsed; overrides.add(field); } else invalid(field, "an extension-to-language-id object");
+        break;
+      }
+      case "initializationOptions": {
+        const parsed = safeClone(value);
+        if (isObject(parsed)) { next.initializationOptions = parsed; overrides.add(field); }
+        else invalid(field, "an object without forbidden keys");
+        break;
+      }
+      case "diagnosticsWaitMs":
+        if (typeof value === "number" && Number.isFinite(value)) next.diagnosticsWaitMs = clampDiagnosticsWaitMs(value);
+        else invalid(field, "a finite number");
+        break;
+      case "disabled":
+        if (typeof value === "boolean") next.disabled = value;
+        else invalid(field, "a boolean");
+        break;
+    }
+  }
+  next.globalOverrides = overrides;
+  return next;
+}
+
+export function resolveLSPConfig(options: ResolveLSPConfigOptions): LSPConfigResult {
+  const warnings: LSPConfigWarning[] = [];
+  const globalPath = options.globalConfigPath ?? defaultGlobalLSPConfigPath();
+  const projectPath = options.projectConfigPath ?? path.join(options.cwd, options.configDirName ?? ".pi", "lsp.json");
+  const resolved = new Map<string, ResolvedLSPServerConfig>();
+
+  for (const builtin of options.builtins) {
+    if (FORBIDDEN_KEYS.has(builtin.id)) continue;
+    resolved.set(builtin.id, copyDefinition(builtin, true));
+  }
+
+  const global = readConfig(globalPath, warnings);
+  if (global) {
+    for (const [id, entry] of serverEntries(global, globalPath, warnings)) {
+      try {
+        const next = applyGlobalEntry(id, entry, resolved.get(id), globalPath, warnings);
+        if (next) resolved.set(id, next);
+      } catch (error) {
+        warnings.push({
+          path: globalPath,
+          server: id,
+          message: `Ignored malformed server config: ${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
+    }
+  }
+
+  const project = readConfig(projectPath, warnings);
+  if (project) {
+    for (const [id, entry] of serverEntries(project, projectPath, warnings)) {
+      const server = resolved.get(id);
+      if (!server) {
+        warnings.push({ path: projectPath, server: id, message: "Ignored project server: project config cannot define servers" });
+        continue;
+      }
+      for (const key of Object.keys(entry)) {
+        if (FORBIDDEN_KEYS.has(key) || !PROJECT_FIELDS.has(key)) {
+          warnings.push({ path: projectPath, server: id, message: `Ignored privileged project field: ${key}` });
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "disabled")) {
+        if (entry.disabled === true) server.disabled = true;
+        else warnings.push({ path: projectPath, server: id, message: "Ignored disabled value; project config may only set true" });
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "diagnosticsWaitMs")) {
+        if (typeof entry.diagnosticsWaitMs === "number" && Number.isFinite(entry.diagnosticsWaitMs)) {
+          server.diagnosticsWaitMs = clampDiagnosticsWaitMs(entry.diagnosticsWaitMs);
+        } else {
+          warnings.push({ path: projectPath, server: id, message: "Ignored invalid diagnosticsWaitMs; expected a finite number" });
+        }
+      }
+    }
+  }
+
+  return { servers: [...resolved.values()], warnings };
+}

--- a/lsp/lsp-core.ts
+++ b/lsp/lsp-core.ts
@@ -4,8 +4,15 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import { pathToFileURL, fileURLToPath } from "node:url";
+import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
+import {
+  defaultGlobalLSPConfigPath,
+  resolveLSPConfig,
+  type LSPConfigWarning,
+  type LSPServerDefinition,
+  type ResolvedLSPServerConfig,
+} from "./lsp-config.js";
 import {
   createMessageConnection,
   StreamMessageReader,
@@ -27,7 +34,7 @@ import {
   DocumentSymbolRequest,
   RenameRequest,
   CodeActionRequest,
-} from "vscode-languageserver-protocol/node.js";
+} from "vscode-languageserver-protocol/node";
 import {
   type Diagnostic,
   type Location,
@@ -49,6 +56,7 @@ const INIT_TIMEOUT_MS = 30000;
 const MAX_OPEN_FILES = 30;
 const IDLE_TIMEOUT_MS = 60_000;
 const CLEANUP_INTERVAL_MS = 30_000;
+const CONFIG_DIR_NAME = (PiCodingAgent as unknown as { CONFIG_DIR_NAME?: string }).CONFIG_DIR_NAME ?? ".pi";
 
 export const LANGUAGE_IDS: Record<string, string> = {
   ".dart": "dart", ".ts": "typescript", ".tsx": "typescriptreact",
@@ -58,12 +66,13 @@ export const LANGUAGE_IDS: Record<string, string> = {
   ".py": "python", ".pyi": "python", ".go": "go", ".rs": "rust",
   ".kt": "kotlin", ".kts": "kotlin",
   ".swift": "swift",
+  ".c": "c", ".h": "c",
+  ".cc": "cpp", ".cpp": "cpp", ".cxx": "cpp",
+  ".hpp": "cpp", ".hxx": "cpp",
 };
 
 // Types
-interface LSPServerConfig {
-  id: string;
-  extensions: string[];
+export interface LSPServerConfig extends LSPServerDefinition {
   findRoot: (file: string, cwd: string) => string | undefined;
   spawn: (root: string) => Promise<{ process: ChildProcessWithoutNullStreams; initOptions?: Record<string, unknown> } | undefined>;
 }
@@ -79,6 +88,7 @@ interface LSPClient {
   stderr: string[];
   capabilities?: any;
   root: string;
+  config: ResolvedLSPServerConfig;
   closed: boolean;
 }
 
@@ -143,9 +153,20 @@ function timeout<T>(promise: Promise<T>, ms: number, name: string): Promise<T> {
   });
 }
 
-function simpleSpawn(bin: string, args: string[] = ["--stdio"]) {
+function resolveCommand(command: string): string | undefined {
+  if (path.isAbsolute(command)) {
+    try {
+      if (!fs.statSync(command).isFile()) return undefined;
+      if (process.platform !== "win32") fs.accessSync(command, fs.constants.X_OK);
+      return command;
+    } catch { return undefined; }
+  }
+  return which(command);
+}
+
+function simpleSpawn(bin: string, args: string[] = ["--stdio"]): LSPServerConfig["spawn"] {
   return async (root: string) => {
-    const cmd = which(bin);
+    const cmd = resolveCommand(bin);
     if (!cmd) return undefined;
     return { process: spawn(cmd, args, { cwd: root, stdio: ["pipe", "pipe", "pipe"] }) };
   };
@@ -245,84 +266,6 @@ function findRootSwift(file: string, cwd: string): string | undefined {
   return undefined;
 }
 
-async function runCommand(cmd: string, args: string[], cwd: string): Promise<boolean> {
-  return await new Promise((resolve) => {
-    try {
-      const p = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
-      p.on("error", () => resolve(false));
-      p.on("exit", (code) => resolve(code === 0));
-    } catch {
-      resolve(false);
-    }
-  });
-}
-
-async function ensureJetBrainsKotlinLspInstalled(): Promise<string | undefined> {
-  // Opt-in download (to avoid surprising network activity)
-  const allowDownload = process.env.PI_LSP_AUTO_DOWNLOAD_KOTLIN_LSP === "1" || process.env.PI_LSP_AUTO_DOWNLOAD_KOTLIN_LSP === "true";
-  const installDir = path.join(os.homedir(), ".pi", "agent", "lsp", "kotlin-ls");
-  const launcher = process.platform === "win32"
-    ? path.join(installDir, "kotlin-lsp.cmd")
-    : path.join(installDir, "kotlin-lsp.sh");
-
-  if (fs.existsSync(launcher)) return launcher;
-  if (!allowDownload) return undefined;
-
-  const curl = which("curl");
-  const unzip = which("unzip");
-  if (!curl || !unzip) return undefined;
-
-  try {
-    // Determine latest version
-    const res = await fetch("https://api.github.com/repos/Kotlin/kotlin-lsp/releases/latest", {
-      headers: { "User-Agent": "pi-lsp" },
-    });
-    if (!res.ok) return undefined;
-    const release: any = await res.json();
-    const versionRaw = (release?.name || release?.tag_name || "").toString();
-    const version = versionRaw.replace(/^v/, "");
-    if (!version) return undefined;
-
-    // Map platform/arch to JetBrains naming
-    const platform = process.platform;
-    const arch = process.arch;
-
-    let kotlinArch: string = arch;
-    if (arch === "arm64") kotlinArch = "aarch64";
-    else if (arch === "x64") kotlinArch = "x64";
-
-    let kotlinPlatform: string = platform;
-    if (platform === "darwin") kotlinPlatform = "mac";
-    else if (platform === "linux") kotlinPlatform = "linux";
-    else if (platform === "win32") kotlinPlatform = "win";
-
-    const supportedCombos = new Set(["mac-x64", "mac-aarch64", "linux-x64", "linux-aarch64", "win-x64", "win-aarch64"]);
-    const combo = `${kotlinPlatform}-${kotlinArch}`;
-    if (!supportedCombos.has(combo)) return undefined;
-
-    const assetName = `kotlin-lsp-${version}-${kotlinPlatform}-${kotlinArch}.zip`;
-    const url = `https://download-cdn.jetbrains.com/kotlin-lsp/${version}/${assetName}`;
-
-    fs.mkdirSync(installDir, { recursive: true });
-    const zipPath = path.join(installDir, "kotlin-lsp.zip");
-
-    const okDownload = await runCommand(curl, ["-L", "-o", zipPath, url], installDir);
-    if (!okDownload || !fs.existsSync(zipPath)) return undefined;
-
-    const okUnzip = await runCommand(unzip, ["-o", zipPath, "-d", installDir], installDir);
-    try { fs.rmSync(zipPath, { force: true }); } catch {}
-    if (!okUnzip) return undefined;
-
-    if (process.platform !== "win32") {
-      try { fs.chmodSync(launcher, 0o755); } catch {}
-    }
-
-    return fs.existsSync(launcher) ? launcher : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 async function spawnKotlinLanguageServer(root: string): Promise<ChildProcessWithoutNullStreams | undefined> {
   // Prefer JetBrains Kotlin LSP (Kotlin/kotlin-lsp) – better diagnostics for Gradle/Android projects.
   const explicit = process.env.PI_LSP_KOTLIN_LSP_PATH;
@@ -330,7 +273,7 @@ async function spawnKotlinLanguageServer(root: string): Promise<ChildProcessWith
     return spawnWithFallback(explicit, [["--stdio"]], root);
   }
 
-  const jetbrains = which("kotlin-lsp") || which("kotlin-lsp.sh") || which("kotlin-lsp.cmd") || await ensureJetBrainsKotlinLspInstalled();
+  const jetbrains = which("kotlin-lsp") || which("kotlin-lsp.sh") || which("kotlin-lsp.cmd");
   if (jetbrains) {
     return spawnWithFallback(jetbrains, [["--stdio"]], root);
   }
@@ -351,10 +294,16 @@ async function spawnSourcekitLsp(root: string): Promise<ChildProcessWithoutNullS
   return spawnWithFallback(xcrun, [["sourcekit-lsp"], ["sourcekit-lsp", "--stdio"]], root);
 }
 
-// Server Configs
+// Builtin server definitions. Keep this export stable for consumers and tests.
+function ids(extensions: string[]): Record<string, string> {
+  return Object.fromEntries(extensions.map((extension) => [extension, LANGUAGE_IDS[extension] ?? "plaintext"]));
+}
+
 export const LSP_SERVERS: LSPServerConfig[] = [
   {
-    id: "dart", extensions: [".dart"],
+    id: "dart", command: "dart", args: ["language-server", "--protocol=lsp"],
+    extensions: [".dart"], rootMarkers: ["pubspec.yaml", "analysis_options.yaml"],
+    languageIds: { ".dart": "dart" }, diagnosticsWaitMs: 3000,
     findRoot: (f, cwd) => findRoot(f, cwd, ["pubspec.yaml", "analysis_options.yaml"]),
     spawn: async (root) => {
       let dart = which("dart");
@@ -367,8 +316,8 @@ export const LSP_SERVERS: LSPServerConfig[] = [
             if (flutter) {
               const dir = path.dirname(fs.realpathSync(flutter));
               for (const p of ["cache/dart-sdk/bin/dart", "../cache/dart-sdk/bin/dart"]) {
-                const c = path.join(dir, p);
-                if (fs.existsSync(c)) { dart = c; break; }
+                const candidate = path.join(dir, p);
+                if (fs.existsSync(candidate)) { dart = candidate; break; }
               }
             }
           }
@@ -379,7 +328,10 @@ export const LSP_SERVERS: LSPServerConfig[] = [
     },
   },
   {
-    id: "typescript", extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
+    id: "typescript", command: "typescript-language-server", args: ["--stdio"],
+    extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
+    rootMarkers: ["package.json", "tsconfig.json", "jsconfig.json"],
+    languageIds: ids([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"]), diagnosticsWaitMs: 3000,
     findRoot: (f, cwd) => {
       if (findNearestFile(path.dirname(f), ["deno.json", "deno.jsonc"], cwd)) return undefined;
       return findRoot(f, cwd, ["package.json", "tsconfig.json", "jsconfig.json"]);
@@ -391,30 +343,87 @@ export const LSP_SERVERS: LSPServerConfig[] = [
       return { process: spawn(cmd, ["--stdio"], { cwd: root, stdio: ["pipe", "pipe", "pipe"] }) };
     },
   },
-  { id: "vue", extensions: [".vue"], findRoot: (f, cwd) => findRoot(f, cwd, ["package.json", "vite.config.ts", "vite.config.js"]), spawn: simpleSpawn("vue-language-server") },
-  { id: "svelte", extensions: [".svelte"], findRoot: (f, cwd) => findRoot(f, cwd, ["package.json", "svelte.config.js"]), spawn: simpleSpawn("svelteserver") },
-  { id: "pyright", extensions: [".py", ".pyi"], findRoot: (f, cwd) => findRoot(f, cwd, ["pyproject.toml", "setup.py", "requirements.txt", "pyrightconfig.json"]), spawn: simpleSpawn("pyright-langserver") },
-  { id: "gopls", extensions: [".go"], findRoot: (f, cwd) => findRoot(f, cwd, ["go.work"]) || findRoot(f, cwd, ["go.mod"]), spawn: simpleSpawn("gopls", []) },
   {
-    id: "kotlin", extensions: [".kt", ".kts"],
+    id: "vue", command: "vue-language-server", args: ["--stdio"], extensions: [".vue"],
+    rootMarkers: ["package.json", "vite.config.ts", "vite.config.js"], languageIds: { ".vue": "vue" }, diagnosticsWaitMs: 3000,
+    findRoot: (f, cwd) => findRoot(f, cwd, ["package.json", "vite.config.ts", "vite.config.js"]), spawn: simpleSpawn("vue-language-server"),
+  },
+  {
+    id: "svelte", command: "svelteserver", args: ["--stdio"], extensions: [".svelte"],
+    rootMarkers: ["package.json", "svelte.config.js"], languageIds: { ".svelte": "svelte" }, diagnosticsWaitMs: 3000,
+    findRoot: (f, cwd) => findRoot(f, cwd, ["package.json", "svelte.config.js"]), spawn: simpleSpawn("svelteserver"),
+  },
+  {
+    id: "pyright", command: "pyright-langserver", args: ["--stdio"], extensions: [".py", ".pyi"],
+    rootMarkers: ["pyproject.toml", "setup.py", "requirements.txt", "pyrightconfig.json"], languageIds: ids([".py", ".pyi"]), diagnosticsWaitMs: 3000,
+    findRoot: (f, cwd) => findRoot(f, cwd, ["pyproject.toml", "setup.py", "requirements.txt", "pyrightconfig.json"]), spawn: simpleSpawn("pyright-langserver"),
+  },
+  {
+    id: "gopls", command: "gopls", args: [], extensions: [".go"], rootMarkers: ["go.work", "go.mod"],
+    languageIds: { ".go": "go" }, diagnosticsWaitMs: 3000,
+    findRoot: (f, cwd) => findRoot(f, cwd, ["go.work"]) || findRoot(f, cwd, ["go.mod"]), spawn: simpleSpawn("gopls", []),
+  },
+  {
+    id: "kotlin", command: "kotlin-lsp", args: ["--stdio"], extensions: [".kt", ".kts"],
+    rootMarkers: ["settings.gradle.kts", "settings.gradle", "build.gradle.kts", "build.gradle", "gradlew", "gradlew.bat", "gradle.properties", "pom.xml"],
+    languageIds: ids([".kt", ".kts"]), diagnosticsWaitMs: 30000,
     findRoot: (f, cwd) => findRootKotlin(f, cwd),
     spawn: async (root) => {
       const proc = await spawnKotlinLanguageServer(root);
-      if (!proc) return undefined;
-      return { process: proc };
+      return proc ? { process: proc } : undefined;
     },
   },
   {
-    id: "swift", extensions: [".swift"],
+    id: "swift", command: "sourcekit-lsp", args: [], extensions: [".swift"],
+    rootMarkers: ["Package.swift"], languageIds: { ".swift": "swift" }, diagnosticsWaitMs: 20000,
     findRoot: (f, cwd) => findRootSwift(f, cwd),
     spawn: async (root) => {
       const proc = await spawnSourcekitLsp(root);
-      if (!proc) return undefined;
-      return { process: proc };
+      return proc ? { process: proc } : undefined;
     },
   },
-  { id: "rust-analyzer", extensions: [".rs"], findRoot: (f, cwd) => findRoot(f, cwd, ["Cargo.toml"]), spawn: simpleSpawn("rust-analyzer", []) },
+  {
+    id: "rust-analyzer", command: "rust-analyzer", args: [], extensions: [".rs"], rootMarkers: ["Cargo.toml"],
+    languageIds: { ".rs": "rust" }, diagnosticsWaitMs: 20000,
+    findRoot: (f, cwd) => findRoot(f, cwd, ["Cargo.toml"]), spawn: simpleSpawn("rust-analyzer", []),
+  },
+  {
+    id: "clangd", command: "clangd", args: ["--background-index"],
+    extensions: [".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hxx"],
+    rootMarkers: ["compile_commands.json", ".clangd", "CMakeLists.txt"],
+    languageIds: ids([".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hxx"]), diagnosticsWaitMs: 3000,
+    findRoot: (f, cwd) => findRoot(f, cwd, ["compile_commands.json", ".clangd", "CMakeLists.txt"]),
+    spawn: simpleSpawn("clangd", ["--background-index"]),
+  },
 ];
+
+type RuntimeServerConfig = ResolvedLSPServerConfig & Pick<LSPServerConfig, "findRoot" | "spawn">;
+
+function runtimeServerConfig(resolved: ResolvedLSPServerConfig): RuntimeServerConfig {
+  const builtin = resolved.builtin ? LSP_SERVERS.find((server) => server.id === resolved.id) : undefined;
+  const useBuiltinRoot = builtin && !resolved.globalOverrides.has("rootMarkers");
+  const useBuiltinSpawn = builtin
+    && !resolved.globalOverrides.has("command")
+    && !resolved.globalOverrides.has("args");
+
+  const baseSpawn = useBuiltinSpawn ? builtin.spawn : simpleSpawn(resolved.command, resolved.args);
+  return {
+    ...resolved,
+    findRoot: useBuiltinRoot
+      ? builtin.findRoot
+      : (file, cwd) => findRoot(file, cwd, resolved.rootMarkers),
+    spawn: async (root) => {
+      const handle = await baseSpawn(root);
+      if (!handle) return undefined;
+      return {
+        process: handle.process,
+        initOptions: resolved.globalOverrides.has("initializationOptions")
+          ? resolved.initializationOptions
+          : (handle.initOptions ?? resolved.initializationOptions),
+      };
+    },
+  };
+}
 
 // Singleton Manager
 let sharedManager: LSPManager | null = null;
@@ -449,12 +458,55 @@ export class LSPManager {
   private spawning = new Map<string, Promise<LSPClient | undefined>>();
   private broken = new Set<string>();
   private cwd: string;
+  private serverConfigs: RuntimeServerConfig[];
+  private configWarnings: LSPConfigWarning[];
   private cleanupTimer: NodeJS.Timeout | null = null;
 
-  constructor(cwd: string) {
+  constructor(cwd: string, configPaths: { globalConfigPath?: string; projectConfigPath?: string } = {}) {
     this.cwd = cwd;
+    const config = resolveLSPConfig({
+      cwd,
+      builtins: LSP_SERVERS,
+      configDirName: CONFIG_DIR_NAME,
+      ...configPaths,
+    });
+    this.serverConfigs = config.servers.filter((server) => !server.disabled).map(runtimeServerConfig);
+    this.configWarnings = config.warnings;
+
+    const specialDiscoveryServers = new Set(["dart", "typescript", "kotlin", "swift"]);
+    for (const server of config.servers) {
+      if (server.builtin && specialDiscoveryServers.has(server.id)
+        && (server.globalOverrides.has("command") || server.globalOverrides.has("args"))) {
+        this.configWarnings.push({
+          path: configPaths.globalConfigPath ?? defaultGlobalLSPConfigPath(),
+          server: server.id,
+          message: "command/args override uses the configured command directly and disables builtin executable discovery/fallbacks",
+        });
+      }
+    }
     this.cleanupTimer = setInterval(() => this.cleanupIdleFiles(), CLEANUP_INTERVAL_MS);
     this.cleanupTimer.unref();
+  }
+
+  getConfigWarnings(): readonly LSPConfigWarning[] { return this.configWarnings; }
+
+  getServerConfigs(): readonly ResolvedLSPServerConfig[] { return this.serverConfigs; }
+
+  getServersForFile(filePath: string): readonly ResolvedLSPServerConfig[] {
+    const extension = path.extname(filePath).toLowerCase();
+    return this.serverConfigs.filter((server) => server.extensions.includes(extension));
+  }
+
+  getServerForFile(filePath: string): ResolvedLSPServerConfig | undefined {
+    return this.getServersForFile(filePath)[0];
+  }
+
+  diagnosticsWaitMsForFile(filePath: string): number {
+    const extension = path.extname(filePath).toLowerCase();
+    const waits = this.serverConfigs
+      .filter((server) => server.extensions.includes(extension))
+      .map((server) => server.diagnosticsWaitMs);
+    return waits.length ? Math.max(...waits) : 3000;
   }
 
   private cleanupIdleFiles() {
@@ -488,7 +540,7 @@ export class LSPManager {
 
   private key(id: string, root: string) { return `${id}:${root}`; }
 
-  private async initClient(config: LSPServerConfig, root: string): Promise<LSPClient | undefined> {
+  private async initClient(config: RuntimeServerConfig, root: string): Promise<LSPClient | undefined> {
     const k = this.key(config.id, root);
     try {
       const handle = await config.spawn(root);
@@ -526,6 +578,7 @@ export class LSPManager {
         listeners: new Map(),
         stderr,
         root,
+        config,
         closed: false,
       };
 
@@ -585,12 +638,12 @@ export class LSPManager {
   }
 
   async getClientsForFile(filePath: string): Promise<LSPClient[]> {
-    const ext = path.extname(filePath);
+    const ext = path.extname(filePath).toLowerCase();
     const absPath = path.isAbsolute(filePath) ? filePath : path.resolve(this.cwd, filePath);
     const clients: LSPClient[] = [];
 
-    for (const config of LSP_SERVERS) {
-      if (!config.extensions.includes(ext)) continue;
+    for (const config of this.serverConfigs) {
+      if (!config.extensions.includes(ext.toLowerCase())) continue;
       const root = config.findRoot(absPath, this.cwd);
       if (!root) continue;
       const k = this.key(config.id, root);
@@ -614,7 +667,10 @@ export class LSPManager {
     const abs = path.isAbsolute(fp) ? fp : path.resolve(this.cwd, fp);
     return normalizeFsPath(abs);
   }
-  private langId(fp: string) { return LANGUAGE_IDS[path.extname(fp)] || "plaintext"; }
+  private langId(client: LSPClient, fp: string) {
+    const extension = path.extname(fp).toLowerCase();
+    return client.config.languageIds[extension] ?? LANGUAGE_IDS[extension] ?? "plaintext";
+  }
   private readFile(fp: string): string | null { try { return fs.readFileSync(fp, "utf-8"); } catch { return null; } }
 
   private explainNoLsp(absPath: string): string {
@@ -675,9 +731,10 @@ export class LSPManager {
     return result as DocumentSymbol[];
   }
 
-  private async openOrUpdate(clients: LSPClient[], absPath: string, uri: string, langId: string, content: string, evict = true) {
+  private async openOrUpdate(clients: LSPClient[], absPath: string, uri: string, content: string, evict = true) {
     const now = Date.now();
     for (const client of clients) {
+      const langId = this.langId(client, absPath);
       if (client.closed) continue;
       const state = client.openFiles.get(absPath);
       try {
@@ -713,7 +770,7 @@ export class LSPManager {
     if (!clients.length) return null;
     const content = this.readFile(absPath);
     if (content === null) return null;
-    return { clients, absPath, uri: pathToFileURL(absPath).href, langId: this.langId(absPath), content };
+    return { clients, absPath, uri: pathToFileURL(absPath).href, content };
   }
 
   private waitForDiagnostics(client: LSPClient, absPath: string, timeoutMs: number, isNew: boolean): Promise<boolean> {
@@ -832,11 +889,10 @@ export class LSPManager {
     }
 
     const uri = pathToFileURL(absPath).href;
-    const langId = this.langId(absPath);
     const isNew = clients.some(c => !c.openFiles.has(absPath));
 
     const waits = clients.map(c => this.waitForDiagnostics(c, absPath, timeoutMs, isNew));
-    await this.openOrUpdate(clients, absPath, uri, langId, content);
+    await this.openOrUpdate(clients, absPath, uri, content);
     const results = await Promise.all(waits);
 
     let responded = results.some(r => r);
@@ -890,7 +946,6 @@ export class LSPManager {
       }
 
       const uri = pathToFileURL(absPath).href;
-      const langId = this.langId(absPath);
       const isNew = clients.some(c => !c.openFiles.has(absPath));
 
       for (const c of clients) {
@@ -901,7 +956,7 @@ export class LSPManager {
       }
 
       const waits = clients.map(c => this.waitForDiagnostics(c, absPath, timeoutMs, isNew));
-      await this.openOrUpdate(clients, absPath, uri, langId, content, false);
+      await this.openOrUpdate(clients, absPath, uri, content, false);
       const waitResults = await Promise.all(waits);
 
       const diags: Diagnostic[] = [];
@@ -938,7 +993,7 @@ export class LSPManager {
   async getDefinition(fp: string, line: number, col: number): Promise<Location[]> {
     const l = await this.loadFile(fp);
     if (!l) return [];
-    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.langId, l.content);
+    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.content);
     const pos = this.toPos(line, col);
     const results = await Promise.all(l.clients.map(async c => {
       if (c.closed) return [];
@@ -951,7 +1006,7 @@ export class LSPManager {
   async getReferences(fp: string, line: number, col: number): Promise<Location[]> {
     const l = await this.loadFile(fp);
     if (!l) return [];
-    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.langId, l.content);
+    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.content);
     const pos = this.toPos(line, col);
     const results = await Promise.all(l.clients.map(async c => {
       if (c.closed) return [];
@@ -964,7 +1019,7 @@ export class LSPManager {
   async getHover(fp: string, line: number, col: number): Promise<Hover | null> {
     const l = await this.loadFile(fp);
     if (!l) return null;
-    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.langId, l.content);
+    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.content);
     const pos = this.toPos(line, col);
     for (const c of l.clients) {
       if (c.closed) continue;
@@ -977,7 +1032,7 @@ export class LSPManager {
   async getSignatureHelp(fp: string, line: number, col: number): Promise<SignatureHelp | null> {
     const l = await this.loadFile(fp);
     if (!l) return null;
-    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.langId, l.content);
+    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.content);
     const pos = this.toPos(line, col);
     for (const c of l.clients) {
       if (c.closed) continue;
@@ -990,7 +1045,7 @@ export class LSPManager {
   async getDocumentSymbols(fp: string): Promise<DocumentSymbol[]> {
     const l = await this.loadFile(fp);
     if (!l) return [];
-    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.langId, l.content);
+    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.content);
     const results = await Promise.all(l.clients.map(async c => {
       if (c.closed) return [];
       try { return this.normalizeSymbols(await c.connection.sendRequest(DocumentSymbolRequest.type, { textDocument: { uri: l.uri } })); }
@@ -1002,7 +1057,7 @@ export class LSPManager {
   async rename(fp: string, line: number, col: number, newName: string): Promise<WorkspaceEdit | null> {
     const l = await this.loadFile(fp);
     if (!l) return null;
-    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.langId, l.content);
+    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.content);
     const pos = this.toPos(line, col);
     for (const c of l.clients) {
       if (c.closed) continue;
@@ -1021,7 +1076,7 @@ export class LSPManager {
   async getCodeActions(fp: string, startLine: number, startCol: number, endLine?: number, endCol?: number): Promise<(CodeAction | Command)[]> {
     const l = await this.loadFile(fp);
     if (!l) return [];
-    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.langId, l.content);
+    await this.openOrUpdate(l.clients, l.absPath, l.uri, l.content);
     
     const start = this.toPos(startLine, startCol);
     const end = this.toPos(endLine ?? startLine, endCol ?? startCol);

--- a/lsp/lsp-tool.ts
+++ b/lsp/lsp-tool.ts
@@ -13,9 +13,10 @@
  *   - Svelte (svelteserver)
  *   - Python (pyright-langserver)
  *   - Go (gopls)
- *   - Kotlin (kotlin-ls)
+ *   - Kotlin (kotlin-lsp, with kotlin-language-server fallback)
  *   - Swift (sourcekit-lsp)
  *   - Rust (rust-analyzer)
+ *   - C/C++ (clangd)
  *
  * Usage:
  *   pi --extension ./lsp-tool.ts
@@ -30,16 +31,6 @@ import { Text } from "@earendil-works/pi-tui";
 import { getOrCreateManager, formatDiagnostic, filterDiagnosticsBySeverity, uriToPath, resolvePosition, collectSymbols, type SeverityFilter } from "./lsp-core.js";
 
 const PREVIEW_LINES = 10;
-
-const DIAGNOSTICS_WAIT_MS_DEFAULT = 3000;
-
-function diagnosticsWaitMsForFile(filePath: string): number {
-  const ext = path.extname(filePath).toLowerCase();
-  if (ext === ".kt" || ext === ".kts") return 30000;
-  if (ext === ".swift") return 20000;
-  if (ext === ".rs") return 20000;
-  return DIAGNOSTICS_WAIT_MS_DEFAULT;
-}
 
 const ACTIONS = ["definition", "references", "hover", "symbols", "diagnostics", "workspace-diagnostics", "signature", "rename", "codeAction"] as const;
 const SEVERITY_FILTERS = ["all", "error", "warning", "info", "hint"] as const;
@@ -266,7 +257,7 @@ Use bash to find files: find src -name "*.ts" -type f`,
             return { content: [{ type: "text", text: `action: symbols\n${qLine}${payload}` }], details: symbols };
           }
           case "diagnostics": {
-            const result = await abortable(manager.touchFileAndWait(file!, diagnosticsWaitMsForFile(file!)), signal);
+            const result = await abortable(manager.touchFileAndWait(file!, manager.diagnosticsWaitMsForFile(file!)), signal);
             const filtered = filterDiagnosticsBySeverity(result.diagnostics, sevFilter);
             const payload = (result as any).unsupported
               ? `Unsupported: ${(result as any).error || "No LSP for this file."}`
@@ -277,7 +268,7 @@ Use bash to find files: find src -name "*.ts" -type f`,
           }
           case "workspace-diagnostics": {
             if (!files?.length) throw new Error('Action "workspace-diagnostics" requires a "files" array.');
-            const waitMs = Math.max(...files.map(diagnosticsWaitMsForFile));
+            const waitMs = Math.max(...files.map((item) => manager.diagnosticsWaitMsForFile(item)));
             const result = await abortable(manager.getDiagnosticsForFiles(files, waitMs), signal);
             const out: string[] = [];
             let errors = 0, warnings = 0, filesWithIssues = 0;

--- a/lsp/lsp.ts
+++ b/lsp/lsp.ts
@@ -17,20 +17,11 @@ import * as os from "node:os";
 import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { type Diagnostic } from "vscode-languageserver-protocol";
-import { LSP_SERVERS, formatDiagnostic, getOrCreateManager, shutdownManager } from "./lsp-core.js";
+import { formatDiagnostic, getOrCreateManager, shutdownManager } from "./lsp-core.js";
 
 type HookScope = "session" | "global";
 type HookMode = "edit_write" | "agent_end" | "disabled";
 
-const DIAGNOSTICS_WAIT_MS_DEFAULT = 3000;
-
-function diagnosticsWaitMsForFile(filePath: string): number {
-  const ext = path.extname(filePath).toLowerCase();
-  if (ext === ".kt" || ext === ".kts") return 30000;
-  if (ext === ".swift") return 20000;
-  if (ext === ".rs") return 20000;
-  return DIAGNOSTICS_WAIT_MS_DEFAULT;
-}
 const DIAGNOSTICS_PREVIEW_LINES = 10;
 const LSP_IDLE_SHUTDOWN_MS = 2 * 60 * 1000;
 const DIM = "\x1b[2m", GREEN = "\x1b[32m", YELLOW = "\x1b[33m", RESET = "\x1b[0m";
@@ -52,6 +43,9 @@ const WARMUP_MAP: Record<string, string> = {
   "gradlew": ".kt",
   "gradle.properties": ".kt",
   "Package.swift": ".swift",
+  "compile_commands.json": ".cpp",
+  ".clangd": ".cpp",
+  "CMakeLists.txt": ".cpp",
 };
 
 const MODE_LABELS: Record<HookMode, string> = {
@@ -271,20 +265,19 @@ export default function (pi: ExtensionAPI) {
     return new Text(styledLines.join("\n"), 0, 0);
   });
 
-  function getServerConfig(filePath: string) {
-    const ext = path.extname(filePath);
-    return LSP_SERVERS.find((s) => s.extensions.includes(ext));
-  }
-
   function ensureActiveClientForFile(filePath: string, cwd: string): string | undefined {
     const absPath = normalizeFilePath(filePath, cwd);
-    const cfg = getServerConfig(absPath);
-    if (!cfg) return undefined;
+    const configs = getOrCreateManager(cwd).getServersForFile(absPath);
+    if (!configs.length) return undefined;
 
-    if (!activeClients.has(cfg.id)) {
-      activeClients.add(cfg.id);
-      updateLspStatus();
+    let changed = false;
+    for (const cfg of configs) {
+      if (!activeClients.has(cfg.id)) {
+        activeClients.add(cfg.id);
+        changed = true;
+      }
     }
+    if (changed) updateLspStatus();
 
     return absPath;
   }
@@ -315,7 +308,8 @@ export default function (pi: ExtensionAPI) {
     const MAX = 5;
     const lines = diagnostics.slice(0, MAX).map((e) => {
       const sev = e.severity === 1 ? "ERROR" : "WARN";
-      return `${sev}[${e.range.start.line + 1}] ${e.message.split("\n")[0]}`;
+      const message = typeof e.message === "string" ? e.message : e.message.value;
+      return `${sev}[${e.range.start.line + 1}] ${message.split("\n")[0]}`;
     });
 
     let notification = `📋 ${relativePath}\n${lines.join("\n")}`;
@@ -339,7 +333,7 @@ export default function (pi: ExtensionAPI) {
     if (!absPath) return undefined;
 
     try {
-      const result = await manager.touchFileAndWait(absPath, diagnosticsWaitMsForFile(absPath));
+      const result = await manager.touchFileAndWait(absPath, manager.diagnosticsWaitMsForFile(absPath));
       if (!result.receivedResponse) return undefined;
 
       const diagnostics = includeWarnings
@@ -431,6 +425,18 @@ export default function (pi: ExtensionAPI) {
     if (hookMode === "disabled") return;
 
     const manager = getOrCreateManager(ctx.cwd);
+    const configWarnings = manager.getConfigWarnings();
+    for (const warning of configWarnings.slice(0, 5)) {
+      const server = warning.server ? ` [${warning.server}]` : "";
+      const message = `LSP config${server}: ${warning.message}`;
+      if (ctx.hasUI) ctx.ui.notify(message, "warning");
+      else console.error(message);
+    }
+    if (configWarnings.length > 5) {
+      const message = `LSP config: ${configWarnings.length - 5} more warning(s)`;
+      if (ctx.hasUI) ctx.ui.notify(message, "warning");
+      else console.error(message);
+    }
 
     for (const [marker, ext] of Object.entries(WARMUP_MAP)) {
       if (fs.existsSync(path.join(ctx.cwd, marker))) {
@@ -438,7 +444,7 @@ export default function (pi: ExtensionAPI) {
         manager.getClientsForFile(path.join(ctx.cwd, `dummy${ext}`))
           .then((clients) => {
             if (clients.length > 0) {
-              const cfg = LSP_SERVERS.find((s) => s.extensions.includes(ext));
+              const cfg = manager.getServerForFile(`dummy${ext}`);
               if (cfg) activeClients.add(cfg.id);
             }
           })
@@ -449,17 +455,7 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  pi.on("session_switch", async (_event, ctx) => {
-    restoreHookState(ctx);
-    updateLspStatus();
-  });
-
   pi.on("session_tree", async (_event, ctx) => {
-    restoreHookState(ctx);
-    updateLspStatus();
-  });
-
-  pi.on("session_fork", async (_event, ctx) => {
     restoreHookState(ctx);
     updateLspStatus();
   });
@@ -578,14 +574,13 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("tool_result", async (event, ctx) => {
     if (event.toolName !== "write" && event.toolName !== "edit") return;
+    if (hookMode === "disabled") return;
 
     const filePath = event.input.path as string;
     if (!filePath) return;
 
     const absPath = ensureActiveClientForFile(filePath, ctx.cwd);
     if (!absPath) return;
-
-    if (hookMode === "disabled") return;
 
     if (hookMode === "agent_end") {
       const includeWarnings = event.toolName === "write";

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -1,9 +1,10 @@
 {
   "name": "lsp-pi",
   "version": "1.0.5",
-  "description": "LSP extension for pi-coding-agent - provides language server tool and diagnostics feedback for Dart/Flutter, TypeScript, Vue, Svelte, Python, Go, Kotlin, Swift, Rust",
+  "description": "LSP extension for pi-coding-agent - one unified LSP tool plus automatic diagnostics for TypeScript, C/C++, Dart, Python, Go, Kotlin, Swift, Rust, Vue, and Svelte",
   "scripts": {
-    "test": "npx tsx tests/lsp.test.ts",
+    "test": "npx tsx tests/lsp.test.ts && npx tsx tests/lsp-config.test.ts",
+    "typecheck": "tsc -p tsconfig.json",
     "test:tool": "npx tsx tests/index.test.ts",
     "test:integration": "npx tsx tests/lsp-integration.test.ts",
     "test:all": "npm test && npm run test:tool && npm run test:integration"
@@ -21,12 +22,24 @@
     "kotlin",
     "swift",
     "rust",
+    "c",
+    "cpp",
+    "clangd",
     "pi-coding-agent",
     "extension",
     "pi-package"
   ],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prateekmedia/pi-hooks.git",
+    "directory": "lsp"
+  },
+  "homepage": "https://github.com/prateekmedia/pi-hooks/tree/main/lsp#readme",
+  "bugs": {
+    "url": "https://github.com/prateekmedia/pi-hooks/issues"
+  },
   "type": "module",
   "pi": {
     "extensions": [
@@ -35,12 +48,12 @@
     ]
   },
   "dependencies": {
-    "vscode-languageserver-protocol": "^3.17.5"
+    "vscode-languageserver-protocol": "^3.18.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",

--- a/lsp/tests/lsp-config.test.ts
+++ b/lsp/tests/lsp-config.test.ts
@@ -1,0 +1,168 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveLSPConfig, type LSPServerDefinition } from "../lsp-config.js";
+import { LSPManager } from "../lsp-core.js";
+
+const builtin: LSPServerDefinition = {
+  id: "builtin",
+  command: "builtin-ls",
+  args: ["--stdio"],
+  extensions: [".one"],
+  rootMarkers: ["project.one"],
+  languageIds: { ".one": "one" },
+  initializationOptions: { original: true },
+  diagnosticsWaitMs: 3000,
+};
+
+const tests: Array<{ name: string; fn: () => Promise<void> }> = [];
+function test(name: string, fn: () => Promise<void>) { tests.push({ name, fn }); }
+function assert(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(message); }
+function equal(actual: unknown, expected: unknown, message: string) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+async function withConfigs(globalValue: string | object | undefined, projectValue: string | object | undefined, fn: (paths: { cwd: string; global: string; project: string }) => Promise<void>) {
+  const dir = await mkdtemp(join(tmpdir(), "lsp-config-test-"));
+  const cwd = join(dir, "project");
+  const global = join(dir, "global.json");
+  const project = join(cwd, ".pi", "lsp.json");
+  await mkdir(join(cwd, ".pi"), { recursive: true });
+  if (globalValue !== undefined) await writeFile(global, typeof globalValue === "string" ? globalValue : JSON.stringify(globalValue));
+  if (projectValue !== undefined) await writeFile(project, typeof projectValue === "string" ? projectValue : JSON.stringify(projectValue));
+  try { await fn({ cwd, global, project }); } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+function resolve(paths: { cwd: string; global: string; project: string }) {
+  return resolveLSPConfig({ cwd: paths.cwd, builtins: [builtin], globalConfigPath: paths.global, projectConfigPath: paths.project });
+}
+
+test("global config can override a builtin and define a server", async () => {
+  await withConfigs({ servers: {
+    builtin: { command: "/opt/bin/one-ls", args: ["--new"], diagnosticsWaitMs: 5000 },
+    custom: { command: "custom-ls", extensions: [".CUSTOM"], rootMarkers: ["custom.toml"], languageIds: { ".CUSTOM": "custom" } },
+  } }, undefined, async (paths) => {
+    const result = resolve(paths);
+    const changed = result.servers.find((server) => server.id === "builtin")!;
+    const custom = result.servers.find((server) => server.id === "custom")!;
+    equal(changed.command, "/opt/bin/one-ls", "builtin command override");
+    equal(changed.args, ["--new"], "builtin args override");
+    equal(changed.diagnosticsWaitMs, 5000, "builtin wait override");
+    assert(custom.command === "custom-ls" && custom.extensions[0] === ".custom", "custom server extensions should normalize");
+    equal(custom.languageIds, { ".custom": "custom" }, "custom language ids should normalize");
+  });
+});
+
+test("project config cannot add a server or change executable surfaces", async () => {
+  await withConfigs(undefined, { servers: {
+    builtin: { command: "/tmp/evil", args: ["--evil"], extensions: [".evil"], rootMarkers: ["evil"], languageIds: { ".evil": "evil" }, initializationOptions: { evil: true }, diagnosticsWaitMs: 7000 },
+    projectOnly: { command: "evil", extensions: [".evil"], rootMarkers: ["evil"] },
+  } }, async (paths) => {
+    const result = resolve(paths);
+    const server = result.servers.find((item) => item.id === "builtin")!;
+    equal(server.command, builtin.command, "project command must be ignored");
+    equal(server.args, builtin.args, "project args must be ignored");
+    equal(server.extensions, builtin.extensions, "project extensions must be ignored");
+    equal(server.rootMarkers, builtin.rootMarkers, "project roots must be ignored");
+    equal(server.languageIds, builtin.languageIds, "project language ids must be ignored");
+    equal(server.initializationOptions, builtin.initializationOptions, "project initialization options must be ignored");
+    equal(server.diagnosticsWaitMs, 7000, "project wait tuning should apply");
+    assert(!result.servers.some((item) => item.id === "projectOnly"), "project server must not be added");
+    assert(result.warnings.some((warning) => warning.message.includes("privileged project field")), "privileged fields should warn");
+    assert(result.warnings.some((warning) => warning.message.includes("cannot define servers")), "new project server should warn");
+  });
+});
+
+test("malformed or oversized JSON leaves builtins working", async () => {
+  await withConfigs("{not json", "[also bad", async (paths) => {
+    const result = resolve(paths);
+    assert(result.servers.length === 1 && result.servers[0].command === builtin.command, "builtin should survive malformed files");
+    assert(result.warnings.length === 2, "both malformed files should warn");
+  });
+
+  await withConfigs(JSON.stringify({ padding: "x".repeat(300_000) }), undefined, async (paths) => {
+    const result = resolve(paths);
+    assert(result.servers.length === 1 && result.servers[0].command === builtin.command, "builtin should survive oversized files");
+    assert(result.warnings.some((warning) => warning.message.includes("exceeds")), "oversized config should warn");
+  });
+});
+
+test("project disable is monotonic", async () => {
+  await withConfigs({ servers: { builtin: { disabled: true } } }, { servers: { builtin: { disabled: false } } }, async (paths) => {
+    const result = resolve(paths);
+    assert(result.servers[0].disabled === true, "project must not re-enable globally disabled server");
+  });
+});
+
+test("diagnostics waits are clamped in both scopes", async () => {
+  await withConfigs({ servers: { builtin: { diagnosticsWaitMs: 1 } } }, { servers: { builtin: { diagnosticsWaitMs: 999999 } } }, async (paths) => {
+    const result = resolve(paths);
+    equal(result.servers[0].diagnosticsWaitMs, 60000, "project upper clamp");
+  });
+  await withConfigs({ servers: { builtin: { diagnosticsWaitMs: 1 } } }, undefined, async (paths) => {
+    equal(resolve(paths).servers[0].diagnosticsWaitMs, 250, "global lower clamp");
+  });
+});
+
+test("relative commands with separators and incomplete new servers are rejected", async () => {
+  await withConfigs({ servers: {
+    builtin: { command: "./relative-ls" },
+    bad: { command: "dir/server", extensions: [".bad"], rootMarkers: ["bad.toml"] },
+    incomplete: { command: "ok-ls", extensions: [".ok"] },
+  } }, undefined, async (paths) => {
+    const result = resolve(paths);
+    equal(result.servers[0].command, builtin.command, "invalid builtin override should be ignored");
+    assert(result.servers.length === 1, "invalid new servers should not be added");
+    assert(result.warnings.length >= 3, "invalid entries should expose warnings");
+  });
+});
+
+test("prototype-pollution keys are ignored", async () => {
+  const json = '{"servers":{"builtin":{"diagnosticsWaitMs":4000,"__proto__":{"polluted":true}},"constructor":{"command":"evil","extensions":[".x"],"rootMarkers":["x"]}}}';
+  await withConfigs(json, undefined, async (paths) => {
+    const result = resolve(paths);
+    equal(result.servers[0].diagnosticsWaitMs, 4000, "safe sibling field should apply");
+    assert(({} as any).polluted === undefined, "Object prototype must remain unchanged");
+    assert(result.warnings.some((warning) => warning.message.includes("forbidden")), "forbidden keys should warn");
+  });
+});
+
+test("manager excludes project-disabled servers and applies safe wait tuning", async () => {
+  await withConfigs(undefined, { servers: { clangd: { disabled: true } } }, async (paths) => {
+    const manager = new LSPManager(paths.cwd, { globalConfigPath: paths.global, projectConfigPath: paths.project });
+    try {
+      assert(manager.getServerForFile("source.cpp") === undefined, "disabled clangd must not match files");
+    } finally {
+      await manager.shutdown();
+    }
+  });
+
+  await withConfigs(undefined, { servers: { clangd: { diagnosticsWaitMs: 9876 } } }, async (paths) => {
+    const manager = new LSPManager(paths.cwd, { globalConfigPath: paths.global, projectConfigPath: paths.project });
+    try {
+      equal(manager.diagnosticsWaitMsForFile("source.cpp"), 9876, "project wait tuning should reach the manager");
+      assert(manager.getServerForFile("source.cpp")?.command === "clangd", "project tuning must preserve builtin command");
+    } finally {
+      await manager.shutdown();
+    }
+  });
+});
+
+test("manager warns when global overrides bypass special executable discovery", async () => {
+  await withConfigs({ servers: { typescript: { args: ["--stdio", "--log-level", "2"] } } }, undefined, async (paths) => {
+    const manager = new LSPManager(paths.cwd, { globalConfigPath: paths.global, projectConfigPath: paths.project });
+    try {
+      assert(manager.getConfigWarnings().some((warning) => warning.server === "typescript" && warning.message.includes("discovery")), "special discovery override should warn");
+    } finally {
+      await manager.shutdown();
+    }
+  });
+});
+
+let failed = 0;
+for (const item of tests) {
+  try { await item.fn(); console.log(`  ${item.name}... ✓`); }
+  catch (error) { failed++; console.error(`  ${item.name}... ✗\n    ${error instanceof Error ? error.message : String(error)}`); }
+}
+console.log(`\n${tests.length - failed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/lsp/tests/lsp-integration.test.ts
+++ b/lsp/tests/lsp-integration.test.ts
@@ -311,6 +311,49 @@ func main() {
 });
 
 // ============================================================================
+// C/C++ (clangd)
+// ============================================================================
+
+test("clangd: detects C++ type errors", async () => {
+  if (!commandExists("clangd")) skip("clangd not installed");
+
+  const dir = await mkdtemp(join(tmpdir(), "lsp-clangd-"));
+  const manager = new LSPManager(dir);
+  try {
+    await writeFile(join(dir, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.20)\nproject(test LANGUAGES CXX)\n");
+    const file = join(dir, "main.cpp");
+    await writeFile(file, 'int main() { const char* value = 42; return value[0]; }\n');
+
+    const { diagnostics, receivedResponse } = await manager.touchFileAndWait(file, 10000);
+    assert(receivedResponse, "Expected clangd to respond");
+    assert(diagnostics.some((diagnostic) => diagnostic.severity === 1), `Expected a clangd error, got: ${diagnostics.map((diagnostic) => diagnostic.message).join(", ")}`);
+  } finally {
+    await manager.shutdown();
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+test("clangd: valid C++ has no errors", async () => {
+  if (!commandExists("clangd")) skip("clangd not installed");
+
+  const dir = await mkdtemp(join(tmpdir(), "lsp-clangd-"));
+  const manager = new LSPManager(dir);
+  try {
+    await writeFile(join(dir, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.20)\nproject(test LANGUAGES CXX)\n");
+    const file = join(dir, "main.cpp");
+    await writeFile(file, "int main() { int value = 42; return value == 42 ? 0 : 1; }\n");
+
+    const { diagnostics, receivedResponse } = await manager.touchFileAndWait(file, 10000);
+    assert(receivedResponse, "Expected clangd to respond");
+    const errors = diagnostics.filter((diagnostic) => diagnostic.severity === 1);
+    assert(errors.length === 0, `Expected no errors, got: ${errors.map((diagnostic) => diagnostic.message).join(", ")}`);
+  } finally {
+    await manager.shutdown();
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+// ============================================================================
 // Kotlin
 // ============================================================================
 

--- a/lsp/tests/lsp.test.ts
+++ b/lsp/tests/lsp.test.ts
@@ -113,6 +113,14 @@ test("LANGUAGE_IDS: Python extensions", async () => {
   assertEquals(LANGUAGE_IDS[".pyi"], "python", ".pyi should map to python");
 });
 
+test("LANGUAGE_IDS: clangd distinguishes C and C++", async () => {
+  assertEquals(LANGUAGE_IDS[".c"], "c", ".c should map to c");
+  assertEquals(LANGUAGE_IDS[".h"], "c", ".h should map to c");
+  for (const ext of [".cc", ".cpp", ".cxx", ".hpp", ".hxx"]) {
+    assertEquals(LANGUAGE_IDS[ext], "cpp", `${ext} should map to cpp`);
+  }
+});
+
 test("LANGUAGE_IDS: Vue/Svelte/Astro extensions", async () => {
   assertEquals(LANGUAGE_IDS[".vue"], "vue", ".vue should map to vue");
   assertEquals(LANGUAGE_IDS[".svelte"], "svelte", ".svelte should map to svelte");
@@ -168,6 +176,44 @@ test("LSP_SERVERS: has Pyright server", async () => {
   assert(server !== undefined, "Should have pyright server");
   assertIncludes(server!.extensions, ".py", "Should handle .py");
   assertIncludes(server!.extensions, ".pyi", "Should handle .pyi");
+});
+
+test("LSP_SERVERS: has clangd with all C/C++ extensions and background index", async () => {
+  const server = LSP_SERVERS.find(s => s.id === "clangd");
+  assert(server !== undefined, "Should have clangd server");
+  for (const ext of [".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hxx"]) {
+    assertIncludes(server!.extensions, ext, `clangd should handle ${ext}`);
+  }
+  assertIncludes(server!.args, "--background-index", "clangd should enable background indexing");
+});
+
+// ============================================================================
+// clangd root detection tests
+// ============================================================================
+
+test("clangd: finds nearest compile_commands.json", async () => {
+  await withTempDir({
+    "CMakeLists.txt": "project(root)",
+    "lib/compile_commands.json": "[]",
+    "lib/src/main.cpp": "int main() {}",
+  }, async (dir) => {
+    const server = LSP_SERVERS.find(s => s.id === "clangd")!;
+    assertEquals(server.findRoot(join(dir, "lib/src/main.cpp"), dir), join(dir, "lib"), "Should use nearest compilation database");
+  });
+});
+
+test("clangd: finds .clangd or CMakeLists.txt and stays within cwd", async () => {
+  await withTempDir({
+    ".clangd": "CompileFlags: {}",
+    "nested/CMakeLists.txt": "project(nested)",
+    "nested/include/api.hpp": "void api();",
+    "outside/project/src/file.c": "int x;",
+  }, async (dir) => {
+    const server = LSP_SERVERS.find(s => s.id === "clangd")!;
+    assertEquals(server.findRoot(join(dir, "nested/include/api.hpp"), dir), join(dir, "nested"), "Should use nearest CMake marker");
+    const cwd = join(dir, "outside/project");
+    assertEquals(server.findRoot(join(cwd, "src/file.c"), cwd), undefined, "Should not search above cwd");
+  });
 });
 
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "keywords": ["pi-package", "pi", "pi-coding-agent"],
   "dependencies": {
     "shell-quote": "^1.8.3",
-    "vscode-languageserver-protocol": "^3.17.5"
+    "vscode-languageserver-protocol": "^3.18.0"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary

- add built-in `clangd` support for C and C++
- add declarative global (`~/.pi/agent/lsp.json`) and project (`.pi/lsp.json`) server configuration
- keep project configuration tuning-only: it cannot define executables, arguments, roots, extensions, language IDs, or initialization options
- preserve the existing one-tool design and `agent_end` diagnostics default
- resolve language IDs and diagnostic waits per server
- remove the opt-in Kotlin downloader so the extension never installs or downloads executables
- update package metadata and the LSP protocol dependency for its current ESM export

## Configuration safety

Global user-owned config may override or add servers. Project config may only disable an existing server or tune its bounded diagnostics timeout. Commands are spawned directly without a shell; relative command paths, prototype-pollution keys, malformed/oversized configs, and project attempts to alter executable surfaces are rejected with warnings.

## Validation

- `npm test`: 73 core + 9 config tests passed
- `npm run test:tool`: 25 passed
- `npm run typecheck`: passed
- `npm run test:integration`: Go integration passed
- `nx -s clang-tools -- npm run test:integration`: clangd error and clean-file cases passed (4 total passed, 0 failed, unavailable servers skipped)
- production tarball loaded successfully in Pi 0.83.0
